### PR TITLE
chore: add all team members as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # the following GitHub users will be requested for
 # review when someone opens a pull request.
-*       @fd0r
-
-
+*       @fd0r @jfrery @andrei-stoian-zama @kcelia @RomanBredehoft


### PR DESCRIPTION
closes https://github.com/zama-ai/concrete-ml-internal/issues/3872