### PR TITLE
chore: improve make check_links

### DIFF
--- a/script/doc_utils/check_no_gitbook_links.sh
+++ b/script/doc_utils/check_no_gitbook_links.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-if grep -r app.gitbook.com docs
-then
-    echo "Error, you have links to (internal?) GitBook, please fix"
-    exit 255
-fi
-
-

--- a/script/make_utils/check_internal_links.sh
+++ b/script/make_utils/check_internal_links.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# We don't want links to the main branch, even if it's public. Instead, release branch should be
+# targeted
+if grep -r "tree/main" docs | grep "\.md:" | grep -v "https://huggingface.co/spaces/"; then
+    echo -n -e "\nThe above links contain references to the main banch. Please remove them as only "
+    echo "release branches should be referenced."
+    exit 255
+fi
+
+
+# We don't want links to our internal repositories (COncrete ML or Concrete), expect if they are
+# GitHub issues
+if grep -r "concrete-ml-internal" docs | grep "\.md:" | grep -v "concrete-ml-internal/issues"; then
+    echo -n -e "\nThe above links contain references to the 'concrete-ml-internal' private "
+    echo -n -e "repository that are not issues. Please remove them as only the 'concrete-ml' "
+    echo "public should be referenced."
+    exit 255
+fi
+
+if grep -r "concrete-internal" docs | grep "\.md:"; then
+    echo -n -e "\nThe above links contain references to the 'concrete-internal' private "
+    echo -n -e "repository that are not issues. Please remove them as only the 'concrete' "
+    echo "public should be referenced."
+    exit 255
+fi
+
+if grep -r app.gitbook.com docs; then
+    echo -e "\nThe above links contain references to our (internal) GitBook. Please remove them."
+    exit 255
+fi

--- a/script/make_utils/check_internal_links.sh
+++ b/script/make_utils/check_internal_links.sh
@@ -9,7 +9,7 @@ if grep -r "tree/main" docs | grep "\.md:" | grep -v "https://huggingface.co/spa
 fi
 
 
-# We don't want links to our internal repositories (COncrete ML or Concrete), expect if they are
+# We don't want links to our internal repositories (Concrete ML or Concrete), expect if they are
 # GitHub issues
 if grep -r "concrete-ml-internal" docs | grep "\.md:" | grep -v "concrete-ml-internal/issues"; then
     echo -n -e "\nThe above links contain references to the 'concrete-ml-internal' private "


### PR DESCRIPTION
We no longer have two `check_links` as the repository is now public (therefore, most links as well)

closes https://github.com/zama-ai/concrete-ml-internal/issues/3881