### PR TITLE
chore: check branch name format when releasing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -542,6 +542,7 @@ changelog: check_version_coherence
 release: check_version_coherence check_apidocs
 	@PROJECT_VER=($$(poetry version)) && \
 	PROJECT_VER="$${PROJECT_VER[1]}" && \
+	./script/release_utils/check_branch_name.sh "$${PROJECT_VER}" && \
 	TAG_NAME="v$${PROJECT_VER}" && \
 	git fetch --tags --force && \
 	git tag -s -a -m "$${TAG_NAME} release" "$${TAG_NAME}" && \

--- a/script/release_utils/check_branch_name.sh
+++ b/script/release_utils/check_branch_name.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Get the current branch name
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+
+CML_VERSION=$1
+
+if [[ -n "$CML_VERSION" ]]; then
+    CML_VERSION_START=$( echo "$CML_VERSION" | cut -d '.' -f -2 )
+    EXPECTED_BRANCH_NAME="release/${CML_VERSION_START}.x"
+
+    # Given a version a.b.c, the current release branch name is expected to have 
+    # format: release/a.b.x
+    if [[ "$$BRANCH_NAME" != "$EXPECTED_BRANCH_NAME" ]]; then											
+        echo "The current branch name does not match the expected release branch name format."
+        echo "Expected $EXPECTED_BRANCH_NAME, but got $BRANCH_NAME."
+        exit 1
+    fi
+else
+    echo "Please provide the project's curent version as input argument."
+fi


### PR DESCRIPTION
For a release of version `a.b.c`, the branch name is expected to be `release/a.b.x`

closes https://github.com/zama-ai/concrete-ml-internal/issues/1957