### PR TITLE
chore: disable CI if internal and push to main

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -75,6 +75,8 @@ env:
 
 jobs:
   matrix-preparation:
+    # We skip the CI in cases of pushing to internal main (because all pushes to main internal are now from the bot)
+    if: ${{ !( github.repository == 'zama-ai/concrete-ml-internal' && github.event_name == 'push' && github.ref == 'refs/heads/main' ) }}
     runs-on: ubuntu-20.04
     timeout-minutes: 5
     outputs:


### PR DESCRIPTION
Now that we have a workflow to force pushes public main to internal main we want to avoid running the CI twice. We can skip it directly in the workflow.