### PR TITLE
chore: avoid crashing internal CI if skipped on main

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -590,6 +590,12 @@ jobs:
       - name: Fail on unsuccessful Linux build
         shell: bash
         run: |
+          # success always if wasn't launched due to CI not supposed to be launched
+          if ${{ !( github.repository == 'zama-ai/concrete-ml-internal' && github.event_name == 'push' && github.ref == 'refs/heads/main' ) }}
+          then
+            exit 0
+          fi
+
           if [[ ${{ needs.build-linux.result }} != "success" ]]; then
             exit 1
           fi


### PR DESCRIPTION
Now that internal main is synced with public main on all pushes to public main and that internal main CI is not launched we also want it to not crash in this case.

Hopefully this commits fixes that.