### PR TITLE
chore: avoid trigger pytest if only the Concrete ML version changes

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -476,6 +476,7 @@ jobs:
           files_yaml: |
             src:
               - src/**
+              - '!src/concrete/ml/version.py'
             tests:
               - tests/**
               - src/concrete/ml/pytest/**


### PR DESCRIPTION
Avoid triggering pytest in the CI when only changing Concrete ML's version (when preparing a release). Changing the version should not affect our tests and everything is tested in the release CI anyway