### PR TITLE
chore: remove wrong Concrete url from docstring

### DIFF
--- a/src/concrete/ml/sklearn/base.py
+++ b/src/concrete/ml/sklearn/base.py
@@ -242,8 +242,8 @@ class BaseEstimator:
         """Get the FHE circuit.
 
         The FHE circuit combines computational graph, mlir, client and server into a single object.
-        More information available in Concrete documentation:
-        https://docs.zama.ai/concrete/developer/terminology_and_structure#terminology
+        More information available in Concrete documentation
+        (https://docs.zama.ai/concrete/getting-started/terminology_and_structure)
         Is None if the model is not fitted.
 
         Returns:


### PR DESCRIPTION
This URL does not exist anymore (preventing us from building the documentation)