### PR TITLE
chore: avoid triggering codeblock tests if SUMMARY.md changed

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -488,6 +488,7 @@ jobs:
               - '**.md'
               - '!.*/**'
               - '!docs/_*/**'
+              - '!docs/SUMMARY.md'
             dependencies:
               - deps_licenses/licenses_linux_user.txt.md5
             conftest:


### PR DESCRIPTION
the docs/SUMMARY.md only has links but no codeblocks, but is changed when updating apidocs (which makes the prepare release CI trigger unnecessary codeblock tests)