### PR TITLE
fix: flaky test double_fit

### DIFF
--- a/tests/sklearn/test_sklearn_models.py
+++ b/tests/sklearn/test_sklearn_models.py
@@ -1230,9 +1230,6 @@ def test_serialization(
     check_serialization(model, x, use_dump_method)
 
 
-# This test is a known flaky
-# FIXME: https://github.com/zama-ai/concrete-ml-internal/issues/3932
-@pytest.mark.flaky
 @pytest.mark.parametrize("model_class, parameters", sklearn_models_and_datasets)
 @pytest.mark.parametrize(
     "n_bits",
@@ -1248,8 +1245,15 @@ def test_double_fit(
 ):
     """Test Double fit."""
 
+    # Generate a random state for generating the first dataset
+    random_state = numpy.random.randint(0, 2**15)
+    parameters["random_state"] = random_state
+
     # Generate two different datasets
     x_1, y_1 = get_dataset(model_class, parameters, n_bits, load_data, is_weekly_option)
+
+    # Make sure the second dataset is different by using a distinct random state
+    parameters["random_state"] += 1
     x_2, y_2 = get_dataset(model_class, parameters, n_bits, load_data, is_weekly_option)
 
     if verbose:


### PR DESCRIPTION
Basically the flaky appeared because we were very unlucky : we were generating 2 datasets sequentially (with fixed seeds) using a new `random_state` each time. This `random_state` was generated through `random_state = numpy.random.randint(0, 2**15)`. Turns out, for seed `1687196373446039357`, two consecutive `randint` calls were outputting the same number (`26567`), which led `get_dataset` / `load_data` to generate the same dataset twice (and thus making the model's predictions identical in the test, while we expect a difference)

I therefore suggest to generate a random state manually once for generating the first dataset and then add 1 to it for generating the second dataset (so that we make sure both random states are different). I believe this should be enough but feel free to suggest other ideas

closes https://github.com/zama-ai/concrete-ml-internal/issues/3932