### PR TITLE
chore: fix import-gpg step in release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -212,14 +212,20 @@ jobs:
       RELEASE_BRANCH_NAME: ${{ needs.release-checks.outputs.release_branch_name }}
 
     steps:
-      # Import GPG key in order to enable the Zama bot to sign all tags
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v5
+      # Create gpg-agent.conf file as the following action raises an issue if it cannot be found
+      - name: Create gpg-agent.conf file
+        run: |
+          touch  ~/.gnupg/gpg-agent.conf
+
+      # Import GPG in order to enable the Zama bot to sign all tags
+      - name: Import GPG
+        uses: crazy-max/ghaction-import-gpg@v5.3.0
         with:
           gpg_private_key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.BOT_GPG_PASSPHRASE }}
           git_user_signingkey: true
           git_tag_gpgsign: true
+          git_config_global: true
 
       # For non-rc releases, create and push the release branch
       - name: Create and push dot release branch to public repository


### PR DESCRIPTION
Looks like there's a small issue in the action where an error is raised if the gpg-agent.conf file cannot be found (not sure what we stumble on it but I'll open an issue on their side). Meanwhile, manually creating the file should do the trick