### PR TITLE
chore: distinguish pytest wheel CI steps

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -733,7 +733,7 @@ jobs:
 
       # Run Pytest on all of our tests (except flaky ones) using PyPI's local wheel during the 
       # release process
-      - name: PyTest with PyPI local wheel of Concrete-ML 
+      - name: PyTest with PyPI local wheel of Concrete-ML (no flaky)
         if: |
           fromJSON(env.IS_RELEASE)
           && steps.conformance.outcome == 'success' 


### PR DESCRIPTION
This is just to distinguish the names when going through GH's interface : 
- `PyTest with PyPI local wheel of Concrete-ML` is used for weekly CIs 
- `PyTest with PyPI local wheel of Concrete-ML (no flaky)` is used for releases