### PR TITLE
chore: handle patch releases

### DIFF
--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -18,7 +18,7 @@ jobs:
       run:
         shell: bash
     env:
-      PROJECT_VERSION: ${{ github.event.inputs.version }}
+      VERSION: ${{ github.event.inputs.version }}
 
     steps:
       # Mask internal URLs if logged
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
         with:
-          ref: "main"
+          ref: ${{ github.ref }}
           token: ${{ secrets.BOT_TOKEN }}
 
       # Make sure that the target branch is main
@@ -64,17 +64,38 @@ jobs:
       - name: Build apidocs
         run: |
           make apidocs
-      
+
+      # Prepare title and branch name for the upcoming pull-request
+      # In case the current version represents a patch release, modify the title and branch name
+      # in order to not trigger the release process once the pull-request is merged, as patch
+      # releases ar expected to be triggered from the existing release branch (and not main)
+      - name: Prepare title and branch name for PR
+        run: |
+          IS_PATCH="$(poetry run python ./script/make_utils/version_utils.py is_patch_release --version ${{ env.VERSION }})"
+
+          BRANCH_PATCH_STRING=""
+          TITLE_PATCH_STRING=""
+          if [[ "${IS_PATCH}" == "true" ]]; then
+            BRANCH_PATCH_STRING="patch_"
+            TITLE_PATCH_STRING="patch "
+          fi
+
+          BRANCH_NAME="chore/prepare_${BRANCH_PATCH_STRING}release_${{ env.VERSION }}"
+          PR_TITLE="Prepare ${TITLE_PATCH_STRING}release ${{ env.VERSION }}"
+
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> "$GITHUB_ENV"
+          echo "PR_TITLE=${PR_TITLE}" >> "$GITHUB_ENV"
+
       # Open a PR with the new version and updated apidocs
       - name: Open PR
         uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666
         with:
           token: ${{ secrets.BOT_TOKEN }}
-          commit-message: "chore: prepare release ${{ env.PROJECT_VERSION }}"
-          branch: "chore/prepare_release_${{ env.PROJECT_VERSION }}"
+          commit-message: "chore: prepare release ${{ env.VERSION }}"
+          branch: "${{ env.BRANCH_NAME }}"
           base: "${{ github.ref_name }}"
-          title: "Prepare release ${{ env.PROJECT_VERSION }}"
-          body: "Set version ${{ env.PROJECT_VERSION }} and build apidocs"
+          title: "${{ env.PR_TITLE }}"
+          body: "Set version ${{ env.VERSION }} and build apidocs"
 
       - name: Slack Notification
         if: ${{ always() && !success() }}
@@ -84,7 +105,7 @@ jobs:
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
           SLACK_ICON: https://pbs.twimg.com/profile_images/1274014582265298945/OjBKP9kn_400x400.png
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MESSAGE: "Preparing release ${{ env.PROJECT_VERSION }} finished with status \ 
+          SLACK_MESSAGE: "Preparing release ${{ env.VERSION }} finished with status \ 
             ${{ job.status }} (${{ env.ACTION_RUN_URL }})"
           SLACK_USERNAME: ${{ secrets.BOT_USERNAME }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,13 +5,17 @@ on:
   workflow_dispatch:
 
   # Releases are also allowed to be automatically triggered once the release preparation 
-  # pull-request (targeting main) is merged. Here, we also make sure that the PR has changes 
-  # in at least one file related to `make set_version` or `make apidocs`
+  # pull-request (targeting main) is merged, as this suggest a rc or major/minor (non-patch) release 
+  # has been prepared. In this case, we also make sure that the PR has changes in at least one file 
+  # related to `make set_version` or `make apidocs`. Additionally, they can also be automatically 
+  # triggered once a PR is merged into a release branch as this suggests we are taking care of a 
+  # patch release
   pull_request:
     types:
       - closed
     branches:
       - main
+      - 'release/'
     paths:
       - src/concrete/ml/version.py
       - 'docs/developer-guide/api/**'
@@ -26,10 +30,12 @@ env:
   BRANCH_IS_RELEASE: ${{ startsWith(github.ref_name, 'release/') }} 
 
 jobs:
-  # Open the AWS EC2 instance if the release process has been triggered manually or if the release 
-  # preparation pull-request has been merged
-  # That latter PR is found by checking for closed PR merged (into main) that contains "Prepare 
-  # release" in their title coming from a branch that starts with "chore/prepare_release_"
+  # Open the AWS EC2 instance if the release process has been triggered manually, if the release 
+  # preparation pull-request has been merged or if a pull-request has been merged in a release 
+  # branch. In the second case, we also make sure that the PR contains "Prepare release" in their 
+  # title coming from a branch that starts with "chore/prepare_release_". This workflow will not 
+  # be triggered if a pull request preparing a patch release is merged as the PR's title and branch
+  # name are expected to be different
   start-runner-linux:
     name: Start EC2 runner
     if: |
@@ -39,6 +45,10 @@ jobs:
         && github.event.pull_request.merged == true
         && startsWith(github.head_ref, 'chore/prepare_release_')
         && contains(github.event.pull_request.title, 'Prepare release')
+      )
+      || (
+        github.event_name == 'pull_request'
+        && "${BRANCH_IS_RELEASE}" == 'true'
       )
     runs-on: ubuntu-20.04
     outputs:
@@ -92,6 +102,7 @@ jobs:
     outputs:
       project_version: ${{ steps.get-release-version.outputs.project_version }}
       is_rc: ${{ steps.get-release-version.outputs.is_rc }}
+      is_patch: ${{ steps.get-release-version.outputs.is_patch }}
       git_tag: ${{ steps.get-release-version.outputs.git_tag }}
       release_branch_name: ${{ steps.get-release-version.outputs.release_branch_name }}
 
@@ -124,12 +135,12 @@ jobs:
       # Make sure that the target branch is:
       # - main, for release-candidates or major/minor releases
       # - a release branch, for patch releases
-      - name: Stop if branch is not main
+      - name: Stop if branch is not main or release
         id: check-branch-is-main
         if: ${{ always() && !cancelled() }}
         run: |
           if [[ "${BRANCH_IS_MAIN}" == "false" && "${BRANCH_IS_RELEASE}" == 'false' ]]; then
-            echo "Release cannot be done: target branch is not main"
+            echo "Release cannot be done: target branch is not main or a release branch"
             exit 1
           fi
 
@@ -154,7 +165,8 @@ jobs:
         id: get-release-version
         run: |
           PROJECT_VERSION="$(poetry version --short)"
-          IS_RC="$(poetry run python ./script/make_utils/version_utils.py isprerelease --version "$PROJECT_VERSION")"
+          IS_RC="$(poetry run python ./script/make_utils/version_utils.py is_prerelease --version "$PROJECT_VERSION")"
+          IS_PATCH="$(poetry run python ./script/make_utils/version_utils.py is_patch_release --version "$PROJECT_VERSION")"
           GIT_TAG="v${PROJECT_VERSION}"
 
           # Release branches are only used for non-release candidates and have a special naming 
@@ -166,6 +178,7 @@ jobs:
           # as environment variables in order to be able to use them in this job's following steps
           echo "PROJECT_VERSION=${PROJECT_VERSION}" >> "$GITHUB_ENV"
           echo "IS_RC=${IS_RC}" >> "$GITHUB_ENV"
+          echo "IS_PATCH=${IS_PATCH}" >> "$GITHUB_ENV"
           echo "GIT_TAG=${GIT_TAG}" >> "$GITHUB_ENV"
           echo "RELEASE_BRANCH_NAME=${RELEASE_BRANCH_NAME}" >> "$GITHUB_ENV"
 
@@ -173,21 +186,32 @@ jobs:
           # candidate as job outputs in order to be able to use them in following jobs
           echo "project_version=${PROJECT_VERSION}" >> "$GITHUB_OUTPUT"
           echo "is_rc=${IS_RC}" >> "$GITHUB_OUTPUT"
+          echo "is_patch=${IS_PATCH}" >> "$GITHUB_OUTPUT"
           echo "git_tag=${GIT_TAG}" >> "$GITHUB_OUTPUT"
           echo "release_branch_name=${RELEASE_BRANCH_NAME}" >> "$GITHUB_OUTPUT"
 
+      # Make sure that the workflow has been triggered from a release branch if this is a patch 
+      # release. Otherwise, the release process is stopped
+      - name: Check patch release is from release branch
+        if:  env.IS_PATCH == 'true'
+        run: |
+          if [[ "${BRANCH_IS_RELEASE}" == "false" ]]; then
+            echo "Patch release cannot be done: target branch is not a release branch"
+            exit 1
+          fi
+
       # Make sure that the tag related to the current version does not already exist in the
-      # repository. If so, the version has not probably been updated. In that case, the release 
-      # process is stopped.
-      - name: Check tag does not remotely exist 
+      # repository. Otherwise, the version has probably not been updated properly and the release 
+      # process is thus stopped
+      - name: Check tag does not exist remotely
         run: |
           ./script/actions_utils/check_tag_not_remote.sh --tag_name "${{ env.GIT_TAG }}"
 
-      # Make sure that the branch related to the current (non-rc) version does not already exist in 
-      # the repository if the workflow has been executed from main (not a patched release). If so, 
-      # the version has probably not been updated. In that case, the release process is stopped.
-      - name: Check dot release branch does not remotely exist
-        if:  env.IS_RC == 'false' && env.BRANCH_IS_MAIN == 'true'
+      # Make sure that the branch related to the current version does not already exist in 
+      # the repository if this is a non-rc and non-patch release. Otherwise, the version has 
+      # probably not been updated properly and the release process is thus stopped
+      - name: Check dot release branch does not exist remotely
+        if:  env.IS_RC == 'false' && env.IS_PATCH == 'false'
         run: |
           ./script/actions_utils/check_branch_not_remote.sh --branch_name "${{ env.RELEASE_BRANCH_NAME }}"
 
@@ -210,6 +234,7 @@ jobs:
         shell: bash
     env:
       IS_RC: ${{ needs.release-checks.outputs.is_rc }}
+      IS_PATCH: ${{ needs.release-checks.outputs.is_patch }}
       GIT_TAG: ${{ needs.release-checks.outputs.git_tag }}
       RELEASE_BRANCH_NAME: ${{ needs.release-checks.outputs.release_branch_name }}
 
@@ -250,10 +275,9 @@ jobs:
         env:
           GNUPGHOME: ${{ env.GPG_HOMEDIR }}
 
-      # For non-rc releases that starts from main, create the release branch as it suggests that 
-      # this is not a patch release
+      # For non-rc and non-patch releases create the new release branch
       - name: Create and push dot release branch to public repository
-        if: env.IS_RC == 'false' && env.BRANCH_IS_MAIN == 'true'
+        if: env.IS_RC == 'false' && env.IS_PATCH == 'false'
         run: |
           git lfs fetch --all
           git checkout -b "${{ env.RELEASE_BRANCH_NAME }}"
@@ -320,7 +344,7 @@ jobs:
           # We want the space separated list of versions to be expanded
           # shellcheck disable=SC2086
           IS_LATEST_INFO=$(poetry run python script/make_utils/version_utils.py \
-          islatest \
+          is_latest \
           --new-version "${{ env.GIT_TAG }}" \
           --existing-versions $EXISTING_TAGS)
 

--- a/script/make_utils/version_utils.py
+++ b/script/make_utils/version_utils.py
@@ -25,8 +25,8 @@ def strip_leading_v(version_str: str):
     return version_str[1:] if version_str.startswith("v") else version_str
 
 
-def islatest(args):
-    """ "islatest command entry point.
+def is_latest_entry(args):
+    """ "is_latest command entry point.
 
     Args:
         args: a Namespace object
@@ -70,8 +70,8 @@ def islatest(args):
         raise RuntimeError(f"Version {args.version} is not valid.")
 
 
-def isprerelease(args):
-    """ "isprerelease command entry point.
+def is_prerelease_entry(args):
+    """ "is_prerelease command entry point.
 
     Args:
         args: a Namespace object
@@ -87,7 +87,30 @@ def isprerelease(args):
         else:
             is_prerelease = True
 
-        print(is_prerelease)
+        print(str(is_prerelease).lower())
+
+    else:
+        raise RuntimeError(f"Version {args.version} is not valid.")
+
+
+def is_patch_release_entry(args):
+    """ "is_patch_release command entry point.
+
+    Args:
+        args: a Namespace object
+
+    Raises:
+        RuntimeError: If the given version is not valid.
+    """
+    version_str = strip_leading_v(args.version)
+    if VersionInfo.isvalid(version_str):
+        new_version_info = VersionInfo.parse(version_str)
+        if new_version_info.patch == 0 or new_version_info.prerelease is not None:
+            is_patch_release = False
+        else:
+            is_patch_release = True
+
+        print(str(is_patch_release).lower())
 
     else:
         raise RuntimeError(f"Version {args.version} is not valid.")
@@ -330,24 +353,30 @@ if __name__ == "__main__":
 
     sub_parsers = main_parser.add_subparsers(dest="sub-command", required=True)
 
-    parser_islatest = sub_parsers.add_parser("islatest")
-    parser_islatest.add_argument(
+    parser_is_latest = sub_parsers.add_parser("is_latest")
+    parser_is_latest.add_argument(
         "--new-version", type=str, required=True, help="The new version to compare"
     )
-    parser_islatest.add_argument(
+    parser_is_latest.add_argument(
         "--existing-versions",
         type=str,
         nargs="+",
         required=True,
         help="The list of existing versions",
     )
-    parser_islatest.set_defaults(entry_point=islatest)
+    parser_is_latest.set_defaults(entry_point=is_latest_entry)
 
-    parser_islatest = sub_parsers.add_parser("isprerelease")
-    parser_islatest.add_argument(
+    parser_is_prerelease = sub_parsers.add_parser("is_prerelease")
+    parser_is_prerelease.add_argument(
         "--version", type=str, required=True, help="The version to consider"
     )
-    parser_islatest.set_defaults(entry_point=isprerelease)
+    parser_is_prerelease.set_defaults(entry_point=is_prerelease_entry)
+
+    parser_is_patch_release = sub_parsers.add_parser("is_patch_release")
+    parser_is_patch_release.add_argument(
+        "--version", type=str, required=True, help="The version to consider"
+    )
+    parser_is_patch_release.set_defaults(entry_point=is_patch_release_entry)
 
     parser_set_version = sub_parsers.add_parser("set-version")
     parser_set_version.add_argument("--version", type=str, required=True, help="The version to set")


### PR DESCRIPTION
Basically, the workflow for patch releases differs a bit as the dot release branch already exists. We'll need to : 
- prepare the release on main as usual. However, this time, the release process won't be automatically triggered (as opposed with major/minor releases or rc)
- manually create a branch from the release branch + cherry pick the necessary commits + open a PR targetting the release branch
- once the PR is merged, the release process is automatically triggered (we therefore accept the release workflow to be triggered from a a release branch, and we won't try to create a new one)