### PR TITLE
chore: run prepare release from release branch for patches

### DIFF
--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -10,6 +10,11 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  BRANCH_NAME: ${{ github.ref_name }}
+  BRANCH_IS_MAIN: ${{ github.ref_name == 'main' }} 
+  BRANCH_IS_RELEASE: ${{ startsWith(github.ref_name, 'release/') }}
+
 jobs:
   prepare-release:
     name: Prepare release ${{ github.event.inputs.version }}
@@ -28,23 +33,23 @@ jobs:
           echo "::add-mask::${{ secrets.INTERNAL_PYPI_URL_FOR_MASK }}"
           echo "::add-mask::${{ secrets.INTERNAL_REPO_URL_FOR_MASK }}"
 
+      # Make sure that the target branch is:
+      # - main, for release-candidates or major/minor releases
+      # - a release branch, for patch releases
+      - name: Stop if branch is not main or release
+        if: ${{ always() && !cancelled() }}
+        run: |
+          if [[ "${BRANCH_IS_MAIN}" == "false" && "${BRANCH_IS_RELEASE}" == 'false' ]]; then
+            echo "Release cannot be done: target branch is not main or a release branch"
+            echo "Got branch ${BRANCH_NAME}"
+            exit 1
+          fi
+
       - name: Checkout Code
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
         with:
           ref: ${{ github.ref }}
           token: ${{ secrets.BOT_TOKEN }}
-
-      # Make sure that the target branch is main
-      - name: Stop if branch is not main
-        id: check-branch-is-main
-        if: ${{ always() && !cancelled() }}
-        env:
-          BRANCH_IS_MAIN: ${{ github.ref_name == 'main'}} 
-        run: |
-          if [[ "${BRANCH_IS_MAIN}" != "true" ]]; then
-            echo "Release cannot be prepared: target branch is not main"
-            exit 1
-          fi
 
       - name: Set up Python 3.8
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
@@ -57,6 +62,41 @@ jobs:
           python -m pip install poetry==1.2.2
           make setup_env
 
+      # Make sure that the workflow has been triggered from a release branch if this is a patch 
+      # release or from main otherwise. If not, the release preparation process is stopped
+      # Additionally, for patch releases, if the release branch name does not match the current
+      # release version, the release preparation process is stopped as well
+      - name: Check release preparation is from right branch
+        run: |
+          IS_PATCH="$(poetry run python ./script/make_utils/version_utils.py is_patch_release --version "$VERSION")"
+
+          if [[ "${IS_PATCH}" == 'true']]; then
+
+            if [[ "${BRANCH_IS_RELEASE}" == "false" ]]; then
+              echo "Patch release cannot be done: target branch is not a release branch"
+              echo "Got branch ${BRANCH_NAME}"
+              exit 1
+
+            else
+              # Release branches are only used for non-release candidates and have a special naming 
+              # format (for example, "release/1.1.x" is used for all patch versions related to version 1.1)
+              VERSION_MAJOR_MINOR=$(echo "${VERSION}" | cut -d '.' -f -2)
+              EXPECTED_BRANCH_NAME="release/${VERSION_MAJOR_MINOR}.x"
+
+              if [[ "${EXPECTED_BRANCH_NAME}" != "${BRANCH_NAME}" ]]; then
+                echo "Patch release cannot be done: target branch name does not match the current version"
+                echo "Got branch ${BRANCH_NAME} but for version ${VERSION}"
+                echo "Expected "${EXPECTED_BRANCH_NAME}"
+                exit 1
+              fi
+            fi
+
+          elif [[ "${IS_PATCH}" == 'false' && "${BRANCH_IS_MAIN}" == "false" ]]; then
+            echo "Release cannot be done: target branch is not main"
+            echo "Got branch ${BRANCH_NAME}"
+            exit 1
+          fi
+
       - name: Set version
         run: |
           make set_version
@@ -65,36 +105,15 @@ jobs:
         run: |
           make apidocs
 
-      # Prepare title and branch name for the upcoming pull-request
-      # In case the current version represents a patch release, modify the title and branch name
-      # in order to not trigger the release process once the pull-request is merged, as patch
-      # releases ar expected to be triggered from the existing release branch (and not main)
-      - name: Prepare title and branch name for PR
-        run: |
-          IS_PATCH="$(poetry run python ./script/make_utils/version_utils.py is_patch_release --version ${{ env.VERSION }})"
-
-          BRANCH_PATCH_STRING=""
-          TITLE_PATCH_STRING=""
-          if [[ "${IS_PATCH}" == "true" ]]; then
-            BRANCH_PATCH_STRING="patch_"
-            TITLE_PATCH_STRING="patch "
-          fi
-
-          BRANCH_NAME="chore/prepare_${BRANCH_PATCH_STRING}release_${{ env.VERSION }}"
-          PR_TITLE="Prepare ${TITLE_PATCH_STRING}release ${{ env.VERSION }}"
-
-          echo "BRANCH_NAME=${BRANCH_NAME}" >> "$GITHUB_ENV"
-          echo "PR_TITLE=${PR_TITLE}" >> "$GITHUB_ENV"
-
       # Open a PR with the new version and updated apidocs
       - name: Open PR
         uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666
         with:
           token: ${{ secrets.BOT_TOKEN }}
           commit-message: "chore: prepare release ${{ env.VERSION }}"
-          branch: "${{ env.BRANCH_NAME }}"
+          branch: "chore/prepare_release_${{ env.VERSION }}"
           base: "${{ github.ref_name }}"
-          title: "${{ env.PR_TITLE }}"
+          title: "Prepare release ${{ env.VERSION }}"
           body: "Set version ${{ env.VERSION }} and build apidocs"
 
       - name: Slack Notification

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,17 +5,15 @@ on:
   workflow_dispatch:
 
   # Releases are also allowed to be automatically triggered once the release preparation 
-  # pull-request (targeting main) is merged, as this suggest a rc or major/minor (non-patch) release 
-  # has been prepared. In this case, we also make sure that the PR has changes in at least one file 
-  # related to `make set_version` or `make apidocs`. Additionally, they can also be automatically 
-  # triggered once a PR is merged into a release branch as this suggests we are taking care of a 
-  # patch release
+  # pull-request is merged in main (major/minor releases or release candidates) or in a release 
+  # branch (patch releases). We also make sure that the PR has changes in at least one file 
+  # related to `make set_version` or `make apidocs`
   pull_request:
     types:
       - closed
     branches:
       - main
-      - 'release/'
+      - 'release/*'
     paths:
       - src/concrete/ml/version.py
       - 'docs/developer-guide/api/**'
@@ -26,6 +24,7 @@ concurrency:
 
 env:
   ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  BRANCH_NAME: ${{ github.ref_name }}
   BRANCH_IS_MAIN: ${{ github.ref_name == 'main' }} 
   BRANCH_IS_RELEASE: ${{ startsWith(github.ref_name, 'release/') }} 
 
@@ -45,10 +44,6 @@ jobs:
         && github.event.pull_request.merged == true
         && startsWith(github.head_ref, 'chore/prepare_release_')
         && contains(github.event.pull_request.title, 'Prepare release')
-      )
-      || (
-        github.event_name == 'pull_request'
-        && "${BRANCH_IS_RELEASE}" == 'true'
       )
     runs-on: ubuntu-20.04
     outputs:
@@ -107,6 +102,18 @@ jobs:
       release_branch_name: ${{ steps.get-release-version.outputs.release_branch_name }}
 
     steps:
+      # Make sure that the target branch is:
+      # - main, for release candidates or major/minor releases
+      # - a release branch, for patch releases
+      - name: Stop if branch is not main or release
+        if: ${{ always() && !cancelled() }}
+        run: |
+          if [[ "${BRANCH_IS_MAIN}" == "false" && "${BRANCH_IS_RELEASE}" == 'false' ]]; then
+            echo "Release cannot be done: target branch is not main or a release branch"
+            echo "Got branch ${BRANCH_NAME}"
+            exit 1
+          fi
+
       # Replace default archive.ubuntu.com from docker image with fr mirror
       # original archive showed performance issues and is farther away
       - name: Docker container related setup and git installation
@@ -124,18 +131,6 @@ jobs:
         with:
           ref: ${{ github.ref }}
           token: ${{ secrets.BOT_TOKEN }}
-
-      # Make sure that the target branch is:
-      # - main, for release-candidates or major/minor releases
-      # - a release branch, for patch releases
-      - name: Stop if branch is not main or release
-        id: check-branch-is-main
-        if: ${{ always() && !cancelled() }}
-        run: |
-          if [[ "${BRANCH_IS_MAIN}" == "false" && "${BRANCH_IS_RELEASE}" == 'false' ]]; then
-            echo "Release cannot be done: target branch is not main or a release branch"
-            exit 1
-          fi
 
       - name: Install dependencies
         run: |
@@ -177,12 +172,27 @@ jobs:
           echo "release_branch_name=${RELEASE_BRANCH_NAME}" >> "$GITHUB_OUTPUT"
 
       # Make sure that the workflow has been triggered from a release branch if this is a patch 
-      # release. Otherwise, the release process is stopped
-      - name: Check patch release is from release branch
-        if:  env.IS_PATCH == 'true'
+      # release or from main otherwise. If not, the release preparation process is stopped
+      # Additionally, for patch releases, if the release branch name does not match the current
+      # release version, the release preparation process is stopped as well
+      - name: Check release preparation is from right branch
         run: |
-          if [[ "${BRANCH_IS_RELEASE}" == "false" ]]; then
-            echo "Patch release cannot be done: target branch is not a release branch"
+          if [[ "${{ env.IS_PATCH }}" == 'true']]; then
+
+            if [[ "${BRANCH_IS_RELEASE}" == "false" ]]; then
+              echo "Patch release cannot be done: target branch is not a release branch"
+              echo "Got branch ${BRANCH_NAME}"
+              exit 1
+
+            elif [[ "${RELEASE_BRANCH_NAME}" != "${BRANCH_NAME}" ]]; then
+              echo "Patch release cannot be done: target branch name does not match the current version"
+              echo "Got branch ${BRANCH_NAME} for version ${PROJECT_VERSION}"
+              exit 1
+            fi
+
+          elif [[ "${{ env.IS_PATCH }}" == 'false' && "${BRANCH_IS_MAIN}" == "false" ]]; then
+            echo "Release cannot be done: target branch is not main"
+            echo "Got branch ${BRANCH_NAME}"
             exit 1
           fi
 


### PR DESCRIPTION
Basically : 
- for major/minor releases or release candidates : run prepare release from main (else it fails) and the release process will follow automatically (once the preparation pr is merged)
- for patch releases :  run prepare release from the right (ie, with matching version) release branch (else it fails) and the release process will follow automatically (once the preparation pr is merged)