### PR TITLE
fix: fix bad top1 accuracy in cifar_brevitas_training use case

### DIFF
--- a/use_case_examples/cifar_brevitas_training/bnn_pynq_train.py
+++ b/use_case_examples/cifar_brevitas_training/bnn_pynq_train.py
@@ -71,7 +71,7 @@ def parse_args(args):
     )
     add_bool_arg(parser, "detect_nan", default=False)
     # Compute resources
-    parser.add_argument("--num_workers", default=4, type=int, help="Number of workers")
+    parser.add_argument("--num_workers", default=0, type=int, help="Number of workers")
     parser.add_argument("--gpus", type=none_or_str, default=None, help="Comma separated GPUs")
     # Optimizer hyper-parameters
     parser.add_argument("--batch_size", default=100, type=int, help="batch size")

--- a/use_case_examples/cifar_brevitas_training/evaluate_one_example_fhe.py
+++ b/use_case_examples/cifar_brevitas_training/evaluate_one_example_fhe.py
@@ -7,8 +7,7 @@ import torch
 from concrete.fhe.compilation.configuration import Configuration
 from models import cnv_2w2a
 from torch.utils.data import DataLoader
-from torchvision import transforms
-from torchvision.datasets import CIFAR10
+from trainer import get_test_set
 
 from concrete import fhe
 from concrete.ml.deployment.fhe_client_server import FHEModelDev
@@ -65,25 +64,11 @@ checkpoint = torch.load(
 )
 torch_model.load_state_dict(checkpoint["state_dict"], strict=False)
 
-# Get some data that will be used to compile the model to FHE standards
-transform_to_tensor = transforms.Compose(
-    [
-        transforms.ToTensor(),
-        transforms.Lambda(lambda x: 2.0 * x - 1.0),
-    ]  # Normalizes data between -1 and +1
-)
-
-builder = CIFAR10
-
-test_set = builder(
-    root=CURRENT_DIR.joinpath(".datasets/"),
-    train=False,
-    download=True,
-    transform=transform_to_tensor,
-)
-
+# Import and load the CIFAR test dataset
+test_set = get_test_set(dataset="CIFAR10", datadir=CURRENT_DIR.joinpath(".datasets/"))
 test_loader = DataLoader(test_set, batch_size=100, shuffle=False)
 
+# Get the first sample
 x, labels = next(iter(test_loader))
 
 # Parameter `enable_unsafe_features` and `use_insecure_key_cache` are needed in order to be able to


### PR DESCRIPTION
We observed a small (~1.5% with 6 bits rounding) drop in accuracy when using a better (more representative) compilation inputset, which is currently being investigated : https://github.com/zama-ai/concrete-ml-internal/issues/3957

In the mean time, this should solve the very low top1 accuracy we currently face (17% -> 86% top1 accuracy with 6 bits rounding)  

closes https://github.com/zama-ai/concrete-ml-internal/issues/3939