### PR TITLE
chore: trigger CI if Makefile changes

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -508,10 +508,13 @@ jobs:
               - deps_licenses/licenses_linux_user.txt.md5
             conftest:
               - conftest.py
+            makefile:
+              - Makefile
 
       # Run determinism test. The only case where this is not run is for a PR that does not modify
       # anything in the source code or the determinism test file. This step is also triggered
-      # if any dependency has been updated or the conftest.py file has changed
+      # if any dependency has been updated or if some changes were found in the conftest.py as well
+      # as the Makefile
       - name: Determinism
         id: determinism
         if: |
@@ -521,6 +524,7 @@ jobs:
             && steps.changed-files-in-pr.outputs.src_any_changed == 'false'
             && steps.changed-files-in-pr.outputs.dependencies_any_changed == 'false'
             && steps.changed-files-in-pr.outputs.conftest_any_changed == 'false'
+            && steps.changed-files-in-pr.outputs.makefile_any_changed == 'false'
           )
           && steps.install-deps.outcome == 'success' 
           && steps.make-pcc.outcome == 'success' 
@@ -528,7 +532,8 @@ jobs:
         run: |
           make determinism
 
-      # Build the documentation if anything changed in our documentation files or in the source code
+      # Build the documentation if anything changed in our documentation files, in the source code
+      # or in the makefile
       - name: Build docs
         id: build-docs
         if: |
@@ -536,6 +541,7 @@ jobs:
             steps.changed-files-in-pr.outcome == 'success' 
             && steps.changed-files-in-pr.outputs.docs_any_changed == 'false' 
             && steps.changed-files-in-pr.outputs.src_any_changed == 'false'
+            && steps.changed-files-in-pr.outputs.makefile_any_changed == 'false'
           )
           && steps.install-deps.outcome == 'success' 
           && steps.make-pcc.outcome == 'success' 
@@ -624,7 +630,8 @@ jobs:
       
       # Run Pytest on a subset of our tests if the source code or our tests has changed, and if the 
       # current workflow does no take place in a weekly or release CI. This step is also triggered
-      # if any dependency has been updated or the conftest.py files has changed
+      # if any dependency has been updated or if some changes were found in the conftest.py as well
+      # as the Makefile
       # If regular tests failed, a following script checks for flaky tests. If all failed tests 
       # are known flaky tests, they are re-run. Otherwise, the step exits with status 1.
       # The 'bash +e {0}' is added here in order to make sure that the step does not exit directly 
@@ -638,6 +645,7 @@ jobs:
             || steps.changed-files-in-pr.outputs.tests_any_changed == 'true'
             || steps.changed-files-in-pr.outputs.dependencies_any_changed == 'true'
             || steps.changed-files-in-pr.outputs.conftest_any_changed == 'true'
+            || steps.changed-files-in-pr.outputs.makefile_any_changed == 'true'
           )
           && steps.conformance.outcome == 'success' 
           && !cancelled()
@@ -686,7 +694,7 @@ jobs:
 
       # Run Pytest on codeblocks if the source code or any markdown has changed, or if this is
       # part of the weekly or release CI. This step is also triggered if any dependency has been 
-      # updated 
+      # updated or if some changes were found in the Makefile
       - name: PyTest CodeBlocks
         if: |
           (
@@ -695,6 +703,7 @@ jobs:
               && steps.changed-files-in-pr.outputs.codeblocks_any_changed == 'false'
               && steps.changed-files-in-pr.outputs.src_any_changed == 'false'
               && steps.changed-files-in-pr.outputs.dependencies_any_changed == 'false'
+              && steps.changed-files-in-pr.outputs.makefile_any_changed == 'false'
             ) 
             || fromJSON(env.IS_WEEKLY) 
             || fromJSON(env.IS_RELEASE)


### PR DESCRIPTION
Not a huge fan of triggering the CI if any changes has been found in the makefile as not all commands are impacting the CI, but since there are still a few of them I can't find a better solution than that (cc @bcm-at-zama )

closes https://github.com/zama-ai/concrete-ml-internal/issues/3955