### PR TITLE
chore: run all CI steps if triggered manually

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -32,7 +32,7 @@ on:
         type: string
         default: "3.8 3.9"
       manual_call:
-        description: 'To distinguish workflow_call from workflow_dispatch'
+        description: "Do not uncheck this"
         type: boolean
         required: false
         default: true
@@ -477,12 +477,15 @@ jobs:
       # re-define what this command does by looking at all markdown files that are neither in hidden
       # directories nor in docs/_apidocs or similar paths. Additionally, as for others, we check for
       # changes in the source directory or in installed dependencies.
+      # This step is skipped if it has been manually triggered in GitHub's Action interface as well
+      # as for release and weekly checks, as there are no changes to check in these cases
       - name: Get all changed files from main in PR
         id: changed-files-in-pr
         if: | 
           env.IS_PR
           && !fromJSON(env.IS_WEEKLY) 
           && !fromJSON(env.IS_RELEASE)
+          && !fromJSON(env.IS_WORKFLOW_DISPATCH)
           && steps.install-deps.outcome == 'success'
           && steps.make-pcc.outcome == 'success' 
           && !cancelled()


### PR DESCRIPTION
By default, several steps would be skipped if the CI was triggered manually through GitHub's Action interface (ex: https://github.com/zama-ai/concrete-ml/actions/runs/6123285209/job/16620945850)

I fixed that by skipping the "check for changes" step, which should prevent other steps from being skipped