### PR TITLE
chore: remove custom classifier attributes

### DIFF
--- a/src/concrete/ml/sklearn/base.py
+++ b/src/concrete/ml/sklearn/base.py
@@ -709,7 +709,8 @@ class BaseClassifier(BaseEstimator):
             Optional[numpy.ndarray]: The model's classes.
         """
         warnings.warn(
-            "Attribute 'target_classes_' is now deprecated. Please use 'classes_' instead.",
+            "Attribute 'target_classes_' is now deprecated and will be removed in a future "
+            "version. Please use 'classes_' instead.",
             category=UserWarning,
             stacklevel=2,
         )
@@ -725,8 +726,14 @@ class BaseClassifier(BaseEstimator):
         Returns:
             int: The model's number of classes.
         """
+
+        # Tree-based classifiers from scikit-learn provide a `n_classes_` attribute
+        if self.sklearn_model is not None and hasattr(self.sklearn_model, "n_classes_"):
+            return self.sklearn_model.n_classes_
+
         warnings.warn(
-            "Attribute 'n_classes_' is now deprecated. Please use 'len(classes_)' instead.",
+            "Attribute 'n_classes_' is now deprecated and will be removed in a future version. "
+            "Please use 'len(classes_)' instead.",
             category=UserWarning,
             stacklevel=2,
         )

--- a/src/concrete/ml/sklearn/linear_model.py
+++ b/src/concrete/ml/sklearn/linear_model.py
@@ -526,8 +526,7 @@ class LogisticRegression(SklearnLinearClassifierMixin):
         metadata["post_processing_params"] = self.post_processing_params
 
         # Classifier
-        metadata["target_classes_"] = self.target_classes_
-        metadata["n_classes_"] = self.n_classes_
+        metadata["classes_"] = self.classes_
 
         # Scikit-Learn
         metadata["penalty"] = self.penalty
@@ -567,8 +566,7 @@ class LogisticRegression(SklearnLinearClassifierMixin):
         obj.post_processing_params = metadata["post_processing_params"]
 
         # Classifier
-        obj.target_classes_ = metadata["target_classes_"]
-        obj.n_classes_ = metadata["n_classes_"]
+        obj.classes_ = metadata["classes_"]
 
         # Scikit-Learn
         obj.penalty = metadata["penalty"]

--- a/src/concrete/ml/sklearn/linear_model.py
+++ b/src/concrete/ml/sklearn/linear_model.py
@@ -525,9 +525,6 @@ class LogisticRegression(SklearnLinearClassifierMixin):
         metadata["_q_bias"] = self._q_bias
         metadata["post_processing_params"] = self.post_processing_params
 
-        # Classifier
-        metadata["classes_"] = self.classes_
-
         # Scikit-Learn
         metadata["penalty"] = self.penalty
         metadata["dual"] = self.dual
@@ -564,9 +561,6 @@ class LogisticRegression(SklearnLinearClassifierMixin):
         obj._q_weights = metadata["_q_weights"]
         obj._q_bias = metadata["_q_bias"]
         obj.post_processing_params = metadata["post_processing_params"]
-
-        # Classifier
-        obj.classes_ = metadata["classes_"]
 
         # Scikit-Learn
         obj.penalty = metadata["penalty"]

--- a/src/concrete/ml/sklearn/qnn.py
+++ b/src/concrete/ml/sklearn/qnn.py
@@ -590,6 +590,7 @@ class NeuralNetClassifier(
         metadata["history_"] = self.history_
         metadata["initialized_"] = self.initialized_
         metadata["virtual_params_"] = self.virtual_params_
+        metadata["classes_"] = self.classes_
 
         assert hasattr(
             self, "module__n_layers"
@@ -622,6 +623,7 @@ class NeuralNetClassifier(
         # Instantiate the model
         obj = NeuralNetClassifier(
             module__n_layers=metadata["module__n_layers"],
+            classes=metadata["classes_"],
         )
 
         # Concrete-ML

--- a/src/concrete/ml/sklearn/qnn.py
+++ b/src/concrete/ml/sklearn/qnn.py
@@ -548,8 +548,7 @@ class NeuralNetClassifier(
         metadata["post_processing_params"] = self.post_processing_params
 
         # Classifier
-        metadata["target_classes_"] = self.target_classes_
-        metadata["n_classes_"] = self.n_classes_
+        metadata["classes_"] = self.classes_
 
         # skorch attributes that cannot be serialized
         # FIXME: https://github.com/zama-ai/concrete-ml-internal/issues/3550
@@ -638,8 +637,7 @@ class NeuralNetClassifier(
         obj.post_processing_params = metadata["post_processing_params"]
 
         # Classifier
-        obj.target_classes_ = metadata["target_classes_"]
-        obj.n_classes_ = metadata["n_classes_"]
+        obj.classes_ = metadata["classes_"]
 
         # skorch
         obj.lr = metadata["lr"]

--- a/src/concrete/ml/sklearn/qnn.py
+++ b/src/concrete/ml/sklearn/qnn.py
@@ -547,9 +547,6 @@ class NeuralNetClassifier(
         metadata["quantized_module_"] = self.quantized_module_
         metadata["post_processing_params"] = self.post_processing_params
 
-        # Classifier
-        metadata["classes_"] = self.classes_
-
         # skorch attributes that cannot be serialized
         # FIXME: https://github.com/zama-ai/concrete-ml-internal/issues/3550
         # Disable mypy as running isinstance with a Callable type unexpectedly raises an issue:
@@ -635,9 +632,6 @@ class NeuralNetClassifier(
         obj.onnx_model_ = metadata["onnx_model_"]
         obj.quantized_module_ = metadata["quantized_module_"]
         obj.post_processing_params = metadata["post_processing_params"]
-
-        # Classifier
-        obj.classes_ = metadata["classes_"]
 
         # skorch
         obj.lr = metadata["lr"]

--- a/src/concrete/ml/sklearn/rf.py
+++ b/src/concrete/ml/sklearn/rf.py
@@ -85,9 +85,6 @@ class RandomForestClassifier(BaseTreeClassifierMixin):
         metadata["framework"] = self.framework
         metadata["post_processing_params"] = self.post_processing_params
 
-        # Classifier
-        metadata["classes_"] = self.classes_
-
         # Scikit-Learn
         metadata["n_estimators"] = self.n_estimators
         metadata["bootstrap"] = self.bootstrap
@@ -128,9 +125,6 @@ class RandomForestClassifier(BaseTreeClassifierMixin):
             output_n_bits=obj.n_bits,
         )
         obj.post_processing_params = metadata["post_processing_params"]
-
-        # Classifier
-        obj.classes_ = metadata["classes_"]
 
         # Scikit-Learn
         obj.n_estimators = metadata["n_estimators"]

--- a/src/concrete/ml/sklearn/rf.py
+++ b/src/concrete/ml/sklearn/rf.py
@@ -86,8 +86,7 @@ class RandomForestClassifier(BaseTreeClassifierMixin):
         metadata["post_processing_params"] = self.post_processing_params
 
         # Classifier
-        metadata["target_classes_"] = self.target_classes_
-        metadata["n_classes_"] = self.n_classes_
+        metadata["classes_"] = self.classes_
 
         # Scikit-Learn
         metadata["n_estimators"] = self.n_estimators
@@ -131,8 +130,7 @@ class RandomForestClassifier(BaseTreeClassifierMixin):
         obj.post_processing_params = metadata["post_processing_params"]
 
         # Classifier
-        obj.target_classes_ = metadata["target_classes_"]
-        obj.n_classes_ = metadata["n_classes_"]
+        obj.classes_ = metadata["classes_"]
 
         # Scikit-Learn
         obj.n_estimators = metadata["n_estimators"]

--- a/src/concrete/ml/sklearn/svm.py
+++ b/src/concrete/ml/sklearn/svm.py
@@ -193,8 +193,7 @@ class LinearSVC(SklearnLinearClassifierMixin):
         metadata["post_processing_params"] = self.post_processing_params
 
         # Classifier
-        metadata["target_classes_"] = self.target_classes_
-        metadata["n_classes_"] = self.n_classes_
+        metadata["classes_"] = self.classes_
 
         # Scikit-Learn
         metadata["penalty"] = self.penalty
@@ -232,8 +231,7 @@ class LinearSVC(SklearnLinearClassifierMixin):
         obj.post_processing_params = metadata["post_processing_params"]
 
         # Classifier
-        obj.target_classes_ = metadata["target_classes_"]
-        obj.n_classes_ = metadata["n_classes_"]
+        obj.classes_ = metadata["classes_"]
 
         # Scikit-Learn
         obj.penalty = metadata["penalty"]

--- a/src/concrete/ml/sklearn/svm.py
+++ b/src/concrete/ml/sklearn/svm.py
@@ -192,9 +192,6 @@ class LinearSVC(SklearnLinearClassifierMixin):
         metadata["_q_bias"] = self._q_bias
         metadata["post_processing_params"] = self.post_processing_params
 
-        # Classifier
-        metadata["classes_"] = self.classes_
-
         # Scikit-Learn
         metadata["penalty"] = self.penalty
         metadata["loss"] = self.loss
@@ -229,9 +226,6 @@ class LinearSVC(SklearnLinearClassifierMixin):
         obj._q_weights = metadata["_q_weights"]
         obj._q_bias = metadata["_q_bias"]
         obj.post_processing_params = metadata["post_processing_params"]
-
-        # Classifier
-        obj.classes_ = metadata["classes_"]
 
         # Scikit-Learn
         obj.penalty = metadata["penalty"]

--- a/src/concrete/ml/sklearn/tree.py
+++ b/src/concrete/ml/sklearn/tree.py
@@ -86,8 +86,7 @@ class DecisionTreeClassifier(BaseTreeClassifierMixin):
         metadata["post_processing_params"] = self.post_processing_params
 
         # Classifier
-        metadata["target_classes_"] = self.target_classes_
-        metadata["n_classes_"] = self.n_classes_
+        metadata["classes_"] = self.classes_
 
         # Scikit-Learn
         metadata["criterion"] = self.criterion
@@ -126,8 +125,7 @@ class DecisionTreeClassifier(BaseTreeClassifierMixin):
         obj.post_processing_params = metadata["post_processing_params"]
 
         # Classifier
-        obj.target_classes_ = metadata["target_classes_"]
-        obj.n_classes_ = metadata["n_classes_"]
+        obj.classes_ = metadata["classes_"]
 
         # Scikit-Learn
         obj.criterion = metadata["criterion"]

--- a/src/concrete/ml/sklearn/tree.py
+++ b/src/concrete/ml/sklearn/tree.py
@@ -85,9 +85,6 @@ class DecisionTreeClassifier(BaseTreeClassifierMixin):
         metadata["framework"] = self.framework
         metadata["post_processing_params"] = self.post_processing_params
 
-        # Classifier
-        metadata["classes_"] = self.classes_
-
         # Scikit-Learn
         metadata["criterion"] = self.criterion
         metadata["splitter"] = self.splitter
@@ -123,9 +120,6 @@ class DecisionTreeClassifier(BaseTreeClassifierMixin):
             output_n_bits=obj.n_bits,
         )
         obj.post_processing_params = metadata["post_processing_params"]
-
-        # Classifier
-        obj.classes_ = metadata["classes_"]
 
         # Scikit-Learn
         obj.criterion = metadata["criterion"]

--- a/src/concrete/ml/sklearn/xgb.py
+++ b/src/concrete/ml/sklearn/xgb.py
@@ -127,8 +127,7 @@ class XGBClassifier(BaseTreeClassifierMixin):
         metadata["post_processing_params"] = self.post_processing_params
 
         # Classifier
-        metadata["target_classes_"] = self.target_classes_
-        metadata["n_classes_"] = self.n_classes_
+        metadata["classes_"] = self.classes_
 
         # XGBoost
         metadata["max_depth"] = self.max_depth
@@ -185,8 +184,7 @@ class XGBClassifier(BaseTreeClassifierMixin):
         obj.post_processing_params = metadata["post_processing_params"]
 
         # Classifier
-        obj.target_classes_ = metadata["target_classes_"]
-        obj.n_classes_ = metadata["n_classes_"]
+        obj.classes_ = metadata["classes_"]
 
         # XGBoost
         obj.max_depth = metadata["max_depth"]

--- a/src/concrete/ml/sklearn/xgb.py
+++ b/src/concrete/ml/sklearn/xgb.py
@@ -126,9 +126,6 @@ class XGBClassifier(BaseTreeClassifierMixin):
         metadata["framework"] = self.framework
         metadata["post_processing_params"] = self.post_processing_params
 
-        # Classifier
-        metadata["classes_"] = self.classes_
-
         # XGBoost
         metadata["max_depth"] = self.max_depth
         metadata["learning_rate"] = self.learning_rate
@@ -182,9 +179,6 @@ class XGBClassifier(BaseTreeClassifierMixin):
             output_n_bits=obj.n_bits,
         )
         obj.post_processing_params = metadata["post_processing_params"]
-
-        # Classifier
-        obj.classes_ = metadata["classes_"]
 
         # XGBoost
         obj.max_depth = metadata["max_depth"]

--- a/tests/sklearn/test_qnn.py
+++ b/tests/sklearn/test_qnn.py
@@ -219,7 +219,7 @@ def test_compile_and_calib(
     if is_classifier_or_partial_classifier(model_class):
         y_pred_clear = model.predict(x_train, fhe="disable")
         # Check that the predicted classes are all contained in the model class list
-        assert set(numpy.unique(y_pred_clear)).issubset(set(model.target_classes_))
+        assert set(numpy.unique(y_pred_clear)).issubset(set(model.classes_))
 
     # Compile the model
     model.compile(


### PR DESCRIPTION
This should simplify our code base without breaking anything. Also, it's somewhat necessary for https://github.com/zama-ai/concrete-ml-internal/issues/3809. Since this includes some API breakings, I added property methods with a warning message saying that both attributes are now deprecated 

closes https://github.com/zama-ai/concrete-ml-internal/issues/3835