### PR TITLE
chore: be sure to have keyring installed

### DIFF
--- a/script/make_utils/generate_authenticated_pip_urls.sh
+++ b/script/make_utils/generate_authenticated_pip_urls.sh
@@ -20,6 +20,10 @@ SECRET_EXTRA_INDEX_URL="${SECRET_EXTRA_INDEX_URL//\'/}"
 # echo "pip extra-index-url: ${SECRET_EXTRA_INDEX_URL}"
 
 if [[ "${SECRET_EXTRA_INDEX_URL}" != "" ]]; then
+    # Sometimes, for no obvious reason, keyring is not installed, so let's reinstall it for more
+    # reliance
+    poetry run python -m pip install keyring
+
     CRED_JSON="$(python script/make_utils/pip_auth_util.py \
     --get-credentials-for "${SECRET_EXTRA_INDEX_URL}" \
     --check-netrc-first \


### PR DESCRIPTION
we have seen that, sometimes, keyring was not available, for no obvious reason. I am not able to say when keyring is or is not installed, so let's be sure it's here, by running installation when it's needed (will not do anything if it's already installed) 

closes #https://github.com/zama-ai/concrete-ml-internal/issues/3950