### PR TITLE
fix: fix flaky padding test

### DIFF
--- a/tests/torch/test_compile_torch.py
+++ b/tests/torch/test_compile_torch.py
@@ -1174,9 +1174,6 @@ def test_shape_operations_net(
             assert "lookup_table" not in quantized_module.fhe_circuit.mlir
 
 
-# This test is a known flaky, remove the mark once it's fixed
-# FIXME: https://github.com/zama-ai/concrete-ml-internal/issues/3989
-@pytest.mark.flaky
 def test_torch_padding(default_configuration, check_circuit_has_no_tlu):
     """Test padding in PyTorch using ONNX pad operators."""
     net = PaddingNet()
@@ -1191,7 +1188,7 @@ def test_torch_padding(default_configuration, check_circuit_has_no_tlu):
         p_error=0.01,
     )
 
-    test_input = numpy.random.uniform(size=(1, 1, 2, 2))
+    test_input = numpy.ones((1, 1, 2, 2))
 
     torch_output = net(torch.tensor(test_input)).detach().numpy()
 


### PR DESCRIPTION
The issue was that we assumed that none of the values in the test input were mapped to 0 by the quantization.
This assumption was proved to be false.
A simple way to force that no value is set to 0 by the quantizer, learned over [0,1], is to simply set the test input to 1 everywhere.