### PR TITLE
feat: enable import of fitted linear sklearn models

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -27,7 +27,7 @@ from concrete.ml.sklearn import (
     GammaRegressor,
     PoissonRegressor,
     TweedieRegressor,
-    get_sklearn_neural_net_models,
+    _get_sklearn_neural_net_models,
 )
 from concrete.ml.sklearn.base import (
     BaseTreeEstimatorMixin,
@@ -402,7 +402,7 @@ def load_data():
             )
 
             # Cast inputs to float32 as skorch QNNs don't handle float64 values
-            if is_model_class_in_a_list(model_class, get_sklearn_neural_net_models()):
+            if is_model_class_in_a_list(model_class, _get_sklearn_neural_net_models()):
                 generated_classifier[0] = generated_classifier[0].astype(numpy.float32)
 
             return tuple(generated_classifier)
@@ -420,7 +420,7 @@ def load_data():
 
             # If the model is a neural network and if the data-set only contains a single target
             # (e.g., of shape (n,)), reshape the target array (e.g., to shape (n,1))
-            if is_model_class_in_a_list(model_class, get_sklearn_neural_net_models()):
+            if is_model_class_in_a_list(model_class, _get_sklearn_neural_net_models()):
                 if len(generated_regression[1].shape) == 1:
                     generated_regression[1] = generated_regression[1].reshape(-1, 1)
 

--- a/src/concrete/ml/common/serialization/decoder.py
+++ b/src/concrete/ml/common/serialization/decoder.py
@@ -18,7 +18,7 @@ from ...quantization.quantizers import (
     UniformQuantizationParameters,
     UniformQuantizer,
 )
-from ...sklearn import get_sklearn_all_models
+from ...sklearn import _get_sklearn_all_models
 from . import SUPPORTED_TORCH_ACTIVATIONS, USE_SKOPS
 
 # If USE_SKOPS is False or Skops can't be imported, default to pickle
@@ -49,7 +49,7 @@ _TRUSTED_TORCH_ACTIVATIONS = [
 ]
 
 _TRUSTED_CONCRETE_MODELS = [
-    _get_fully_qualified_name(model_class) for model_class in get_sklearn_all_models()
+    _get_fully_qualified_name(model_class) for model_class in _get_sklearn_all_models()
 ]
 
 # Define all the trusted types that Skops should consider
@@ -184,7 +184,7 @@ def object_hook(d: Any) -> Any:
         # `dump_dict` and `load_dict` method) if not already done
         if not SERIALIZABLE_CLASSES:
             serializable_classes = (
-                get_sklearn_all_models()
+                _get_sklearn_all_models()
                 + list(ALL_QUANTIZED_OPS)
                 + [
                     QuantizedArray,

--- a/src/concrete/ml/common/serialization/decoder.py
+++ b/src/concrete/ml/common/serialization/decoder.py
@@ -18,7 +18,7 @@ from ...quantization.quantizers import (
     UniformQuantizationParameters,
     UniformQuantizer,
 )
-from ...sklearn import get_sklearn_models
+from ...sklearn import get_sklearn_all_models
 from . import SUPPORTED_TORCH_ACTIVATIONS, USE_SKOPS
 
 # If USE_SKOPS is False or Skops can't be imported, default to pickle
@@ -49,7 +49,7 @@ _TRUSTED_TORCH_ACTIVATIONS = [
 ]
 
 _TRUSTED_CONCRETE_MODELS = [
-    _get_fully_qualified_name(model_class) for model_class in get_sklearn_models()["all"]
+    _get_fully_qualified_name(model_class) for model_class in get_sklearn_all_models()
 ]
 
 # Define all the trusted types that Skops should consider
@@ -184,7 +184,7 @@ def object_hook(d: Any) -> Any:
         # `dump_dict` and `load_dict` method) if not already done
         if not SERIALIZABLE_CLASSES:
             serializable_classes = (
-                get_sklearn_models()["all"]
+                get_sklearn_all_models()
                 + list(ALL_QUANTIZED_OPS)
                 + [
                     QuantizedArray,

--- a/src/concrete/ml/pytest/utils.py
+++ b/src/concrete/ml/pytest/utils.py
@@ -26,17 +26,17 @@ from ..sklearn import (
     NeuralNetClassifier,
     NeuralNetRegressor,
     TweedieRegressor,
-    get_sklearn_linear_models,
-    get_sklearn_neighbors_models,
-    get_sklearn_neural_net_models,
-    get_sklearn_tree_models,
+    _get_sklearn_linear_models,
+    _get_sklearn_neighbors_models,
+    _get_sklearn_neural_net_models,
+    _get_sklearn_tree_models,
 )
 
 
-def get_pytest_param_regressor(model):
+def _get_pytest_param_regressor(model):
     """Get the pytest parameters to use for testing the regression model.
 
-    The pytest parameters includes the model itself, the parameters to use for generating the
+    The pytest parameters selects the model itself, the parameters to use for generating the
     regression data-set and the test identifier (the model's name).
 
     Args:
@@ -60,10 +60,10 @@ def get_pytest_param_regressor(model):
     )
 
 
-def get_pytest_param_classifier(model, n_classes: int):
+def _get_pytest_param_classifier(model, n_classes: int):
     """Get the pytest parameters to use for testing the classification model.
 
-    The pytest parameters includes the model itself, the parameters to use for generating the
+    The pytest parameters selects the model itself, the parameters to use for generating the
     classification data-set and the test identifier (the model's name).
 
     Args:
@@ -114,7 +114,7 @@ def _get_sklearn_models_and_datasets(model_classes: List, unique_models: bool = 
 
     for model_class in model_classes:
         if is_regressor_or_partial_regressor(model_class):
-            models_and_datasets.append(get_pytest_param_regressor(model_class))
+            models_and_datasets.append(_get_pytest_param_regressor(model_class))
 
         elif is_classifier_or_partial_classifier(model_class):
 
@@ -130,7 +130,7 @@ def _get_sklearn_models_and_datasets(model_classes: List, unique_models: bool = 
 
             for n_classes in n_classes_to_test:
                 models_and_datasets.append(
-                    get_pytest_param_classifier(model_class, n_classes=n_classes)
+                    _get_pytest_param_classifier(model_class, n_classes=n_classes)
                 )
 
         else:
@@ -145,8 +145,8 @@ def get_sklearn_linear_models_and_datasets(
     regressor: bool = True,
     classifier: bool = True,
     unique_models: bool = False,
-    include: Optional[Union[str, List[str]]] = None,
-    exclude: Optional[Union[str, List[str]]] = None,
+    select: Optional[Union[str, List[str]]] = None,
+    ignore: Optional[Union[str, List[str]]] = None,
 ) -> List:
     """Get the pytest parameters to use for testing linear models.
 
@@ -154,9 +154,9 @@ def get_sklearn_linear_models_and_datasets(
         regressor (bool): If regressors should be selected.
         classifier (bool): If classifiers should be selected.
         unique_models (bool): If each models should be represented only once.
-        include (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+        select (Optional[Union[str, List[str]]]): If not None, only return models which names (or
             a part of it) match the given string or list of strings. Default to None.
-        exclude (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+        ignore (Optional[Union[str, List[str]]]): If not None, only return models which names (or
             a part of it) do not match the given string or list of strings. Default to None.
 
     Returns:
@@ -164,11 +164,11 @@ def get_sklearn_linear_models_and_datasets(
     """
 
     # Get all linear model classes currently available in Concrete ML
-    linear_classes = get_sklearn_linear_models(
+    linear_classes = _get_sklearn_linear_models(
         regressor=regressor,
         classifier=classifier,
-        str_in_class_name=include,
-        str_not_in_class_name=exclude,
+        select=select,
+        ignore=ignore,
     )
 
     # If the TweedieRegressor has been selected and is allowed to be represented more than once,
@@ -188,8 +188,8 @@ def get_sklearn_tree_models_and_datasets(
     regressor: bool = True,
     classifier: bool = True,
     unique_models: bool = False,
-    include: Optional[Union[str, List[str]]] = None,
-    exclude: Optional[Union[str, List[str]]] = None,
+    select: Optional[Union[str, List[str]]] = None,
+    ignore: Optional[Union[str, List[str]]] = None,
 ) -> List:
     """Get the pytest parameters to use for testing tree-based models.
 
@@ -197,20 +197,20 @@ def get_sklearn_tree_models_and_datasets(
         regressor (bool): If regressors should be selected.
         classifier (bool): If classifiers should be selected.
         unique_models (bool): If each models should be represented only once.
-        include (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+        select (Optional[Union[str, List[str]]]): If not None, only return models which names (or
             a part of it) match the given string or list of strings. Default to None.
-        exclude (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+        ignore (Optional[Union[str, List[str]]]): If not None, only return models which names (or
             a part of it) do not match the given string or list of strings. Default to None.
 
     Returns:
         List: The pytest parameters to use for testing tree-based models.
     """
     # Get all tree-based model classes currently available in Concrete ML
-    tree_classes = get_sklearn_tree_models(
+    tree_classes = _get_sklearn_tree_models(
         regressor=regressor,
         classifier=classifier,
-        str_in_class_name=include,
-        str_not_in_class_name=exclude,
+        select=select,
+        ignore=ignore,
     )
 
     return _get_sklearn_models_and_datasets(tree_classes, unique_models=unique_models)
@@ -220,8 +220,8 @@ def get_sklearn_neural_net_models_and_datasets(
     regressor: bool = True,
     classifier: bool = True,
     unique_models: bool = False,
-    include: Optional[Union[str, List[str]]] = None,
-    exclude: Optional[Union[str, List[str]]] = None,
+    select: Optional[Union[str, List[str]]] = None,
+    ignore: Optional[Union[str, List[str]]] = None,
 ) -> List:
     """Get the pytest parameters to use for testing neural network models.
 
@@ -229,9 +229,9 @@ def get_sklearn_neural_net_models_and_datasets(
         regressor (bool): If regressors should be selected.
         classifier (bool): If classifiers should be selected.
         unique_models (bool): If each models should be represented only once.
-        include (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+        select (Optional[Union[str, List[str]]]): If not None, only return models which names (or
             a part of it) match the given string or list of strings. Default to None.
-        exclude (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+        ignore (Optional[Union[str, List[str]]]): If not None, only return models which names (or
             a part of it) do not match the given string or list of strings. Default to None.
 
     Returns:
@@ -239,11 +239,11 @@ def get_sklearn_neural_net_models_and_datasets(
     """
 
     # Get all neural-network model classes currently available in Concrete ML
-    selected_neural_net_classes = get_sklearn_neural_net_models(
+    selected_neural_net_classes = _get_sklearn_neural_net_models(
         regressor=regressor,
         classifier=classifier,
-        str_in_class_name=include,
-        str_not_in_class_name=exclude,
+        select=select,
+        ignore=ignore,
     )
 
     neural_net_classes = []
@@ -284,8 +284,8 @@ def get_sklearn_neighbors_models_and_datasets(
     regressor: bool = True,
     classifier: bool = True,
     unique_models: bool = False,
-    include: Optional[Union[str, List[str]]] = None,
-    exclude: Optional[Union[str, List[str]]] = None,
+    select: Optional[Union[str, List[str]]] = None,
+    ignore: Optional[Union[str, List[str]]] = None,
 ) -> List:
     """Get the pytest parameters to use for testing neighbor models.
 
@@ -293,20 +293,20 @@ def get_sklearn_neighbors_models_and_datasets(
         regressor (bool): If regressors should be selected.
         classifier (bool): If classifiers should be selected.
         unique_models (bool): If each models should be represented only once.
-        include (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+        select (Optional[Union[str, List[str]]]): If not None, only return models which names (or
             a part of it) match the given string or list of strings. Default to None.
-        exclude (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+        ignore (Optional[Union[str, List[str]]]): If not None, only return models which names (or
             a part of it) do not match the given string or list of strings. Default to None.
 
     Returns:
         List: The pytest parameters to use for testing neighbor models.
     """
     # Get all neighbor model classes currently available in Concrete ML
-    neighbor_classes = get_sklearn_neighbors_models(
+    neighbor_classes = _get_sklearn_neighbors_models(
         regressor=regressor,
         classifier=classifier,
-        str_in_class_name=include,
-        str_not_in_class_name=exclude,
+        select=select,
+        ignore=ignore,
     )
 
     return _get_sklearn_models_and_datasets(neighbor_classes, unique_models=unique_models)
@@ -316,8 +316,8 @@ def get_sklearn_all_models_and_datasets(
     regressor: bool = True,
     classifier: bool = True,
     unique_models: bool = False,
-    include: Optional[Union[str, List[str]]] = None,
-    exclude: Optional[Union[str, List[str]]] = None,
+    select: Optional[Union[str, List[str]]] = None,
+    ignore: Optional[Union[str, List[str]]] = None,
 ) -> List:
     """Get the pytest parameters to use for testing all models available in Concrete ML.
 
@@ -325,9 +325,9 @@ def get_sklearn_all_models_and_datasets(
         regressor (bool): If regressors should be selected.
         classifier (bool): If classifiers should be selected.
         unique_models (bool): If each models should be represented only once.
-        include (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+        select (Optional[Union[str, List[str]]]): If not None, only return models which names (or
             a part of it) match the given string or list of strings. Default to None.
-        exclude (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+        ignore (Optional[Union[str, List[str]]]): If not None, only return models which names (or
             a part of it) do not match the given string or list of strings. Default to None.
 
     Returns:
@@ -338,29 +338,29 @@ def get_sklearn_all_models_and_datasets(
             regressor=regressor,
             classifier=classifier,
             unique_models=unique_models,
-            include=include,
-            exclude=exclude,
+            select=select,
+            ignore=ignore,
         )
         + get_sklearn_tree_models_and_datasets(
             regressor=regressor,
             classifier=classifier,
             unique_models=unique_models,
-            include=include,
-            exclude=exclude,
+            select=select,
+            ignore=ignore,
         )
         + get_sklearn_neural_net_models_and_datasets(
             regressor=regressor,
             classifier=classifier,
             unique_models=unique_models,
-            include=include,
-            exclude=exclude,
+            select=select,
+            ignore=ignore,
         )
         + get_sklearn_neighbors_models_and_datasets(
             regressor=regressor,
             classifier=classifier,
             unique_models=unique_models,
-            include=include,
-            exclude=exclude,
+            select=select,
+            ignore=ignore,
         )
     )
 
@@ -389,7 +389,7 @@ def instantiate_model_generic(model_class, n_bits, **parameters):
         model (object): The model instance.
     """
     # If the model is a QNN, set the model using appropriate bit-widths
-    if is_model_class_in_a_list(model_class, get_sklearn_neural_net_models()):
+    if is_model_class_in_a_list(model_class, _get_sklearn_neural_net_models()):
         extra_kwargs = {}
         if n_bits > 8:
             extra_kwargs["module__n_w_bits"] = 3

--- a/src/concrete/ml/pytest/utils.py
+++ b/src/concrete/ml/pytest/utils.py
@@ -12,157 +12,366 @@ from torch import nn
 
 from ..common.serialization.dumpers import dump, dumps
 from ..common.serialization.loaders import load, loads
-from ..common.utils import get_model_class, get_model_name, is_model_class_in_a_list, is_pandas_type
+from ..common.utils import (
+    get_model_class,
+    get_model_name,
+    is_classifier_or_partial_classifier,
+    is_model_class_in_a_list,
+    is_pandas_type,
+    is_regressor_or_partial_regressor,
+)
 from ..sklearn import (
-    DecisionTreeClassifier,
-    DecisionTreeRegressor,
-    ElasticNet,
-    GammaRegressor,
     KNeighborsClassifier,
-    Lasso,
     LinearRegression,
-    LinearSVC,
-    LinearSVR,
-    LogisticRegression,
     NeuralNetClassifier,
     NeuralNetRegressor,
-    PoissonRegressor,
-    RandomForestClassifier,
-    RandomForestRegressor,
-    Ridge,
     TweedieRegressor,
-    XGBClassifier,
-    XGBRegressor,
+    get_sklearn_linear_models,
+    get_sklearn_neighbors_models,
     get_sklearn_neural_net_models,
+    get_sklearn_tree_models,
 )
 
-_regressor_models = [
-    XGBRegressor,
-    GammaRegressor,
-    LinearRegression,
-    Lasso,
-    Ridge,
-    ElasticNet,
-    LinearSVR,
-    PoissonRegressor,
-    TweedieRegressor,
-    partial(TweedieRegressor, link="auto", power=0.0),
-    partial(TweedieRegressor, link="auto", power=2.8),
-    partial(TweedieRegressor, link="log", power=1.0),
-    partial(TweedieRegressor, link="identity", power=0.0),
-    DecisionTreeRegressor,
-    RandomForestRegressor,
-    partial(
-        NeuralNetRegressor,
-        module__n_layers=3,
-        module__n_w_bits=2,
-        module__n_a_bits=2,
-        module__n_accum_bits=7,  # Stay with 7 bits for test exec time
-        module__n_hidden_neurons_multiplier=1,
-        module__activation_function=nn.ReLU,
-        max_epochs=10,
-        verbose=0,
-        callbacks="disable",
-    ),
-]
 
-_classifier_models = [
-    KNeighborsClassifier,
-    DecisionTreeClassifier,
-    RandomForestClassifier,
-    XGBClassifier,
-    LinearSVC,
-    LogisticRegression,
-    partial(
-        NeuralNetClassifier,
-        module__n_layers=3,
-        module__activation_function=nn.ReLU,
-        max_epochs=10,
-        verbose=0,
-        callbacks="disable",
-    ),
-]
+def get_pytest_param_regressor(model):
+    """Get the pytest parameters to use for testing the regression model.
 
-# Get the data-sets. The data generation is seeded in load_data.
-_classifiers_and_datasets = [
-    pytest.param(
-        model,
-        {
-            "n_samples": 1000,
-            "n_features": 10,
-            "n_classes": n_classes,
-            "n_informative": 10,
-            "n_redundant": 0,
-        },
-        id=get_model_name(model),
-    )
-    for model in _classifier_models
-    if get_model_name(model) != "KNeighborsClassifier"
-    for n_classes in [2, 4]
-] + [
-    pytest.param(
-        model,
-        {
-            "n_samples": 6,
-            "n_features": 2,
-            "n_classes": n_classes,
-            "n_informative": 2,
-            "n_redundant": 0,
-        },
-        id=get_model_name(model),
-    )
-    for model in [KNeighborsClassifier]
-    for n_classes in [2]
-]
+    The pytest parameters includes the model itself, the parameters to use for generating the
+    regression data-set and the test identifier (the model's name).
 
+    Args:
+        model: The regression model to consider.
 
-# Get the data-sets. The data generation is seeded in load_data.
-# Only LinearRegression supports multi targets
-# GammaRegressor, PoissonRegressor and TweedieRegressor only handle positive target values
-_regressors_and_datasets = [
-    pytest.param(
+    Returns:
+        The pytest parameters to use for testing the regression model.
+    """
+
+    # We only test LinearRegression models for multiple-targets support
+    return pytest.param(
         model,
         {
             "n_samples": 200,
             "n_features": 10,
             "n_informative": 10,
-            "n_targets": 2 if model == LinearRegression else 1,
+            "n_targets": 2 if get_model_class(model) == LinearRegression else 1,
             "noise": 0,
         },
         id=get_model_name(model),
     )
-    for model in _regressor_models
-]
-
-# All scikit-learn models in Concrete ML
-sklearn_models_and_datasets = _classifiers_and_datasets + _regressors_and_datasets
 
 
-def get_random_extract_of_sklearn_models_and_datasets():
-    """Return a random sublist of sklearn_models_and_datasets.
+def get_pytest_param_classifier(model, n_classes: int):
+    """Get the pytest parameters to use for testing the classification model.
 
-    The sublist contains exactly one model of each kind.
+    The pytest parameters includes the model itself, the parameters to use for generating the
+    classification data-set and the test identifier (the model's name).
+
+    Args:
+        model: The classification model to consider.
+        n_classes (int): The number of classes to consider when generating the dataset.
 
     Returns:
-        the sublist
-
+        The pytest parameters to use for testing the classification model.
     """
-    unique_model_classes = []
-    done = {}
+    if get_model_class(model) == KNeighborsClassifier:
+        dataset_params = {
+            "n_samples": 6,
+            "n_features": 2,
+            "n_classes": n_classes,
+            "n_informative": 2,
+            "n_redundant": 0,
+        }
+    else:
+        dataset_params = {
+            "n_samples": 1000,
+            "n_features": 10,
+            "n_classes": n_classes,
+            "n_informative": 10,
+            "n_redundant": 0,
+        }
 
-    for m in sklearn_models_and_datasets:
-        t = m.values
-        typ = get_model_class(t[0])
+    return pytest.param(
+        model,
+        dataset_params,
+        id=get_model_name(model),
+    )
 
-        if typ not in done:
-            done[typ] = True
-            unique_model_classes.append(m)
 
-    # To avoid to make mistakes and return empty list
-    assert len(sklearn_models_and_datasets) == 29
-    assert len(unique_model_classes) == 19
+def _get_sklearn_models_and_datasets(model_classes: List, unique_models: bool = False) -> List:
+    """Get the pytest parameters to use for testing the given models.
 
-    return unique_model_classes
+    Args:
+        model_classes (List): The models to consider.
+        unique_models (bool): If each models should be represented only once.
+
+    Returns:
+        models_and_datasets (List): The pytest parameters to use for testing the given models.
+
+    Raises:
+        ValueError: If one of the given model is neither considered a regressor nor a classifier.
+    """
+    models_and_datasets = []
+
+    for model_class in model_classes:
+        if is_regressor_or_partial_regressor(model_class):
+            models_and_datasets.append(get_pytest_param_regressor(model_class))
+
+        elif is_classifier_or_partial_classifier(model_class):
+
+            # Unless each models should be represented only once, we test classifier models for both
+            # binary and multiclass classification
+            # Also, only consider 2 classes for the KNeighborsClassifier model in order to decrease
+            # the test execution timings
+            n_classes_to_test = (
+                [2]
+                if unique_models or get_model_class(model_class) == KNeighborsClassifier
+                else [2, 4]
+            )
+
+            for n_classes in n_classes_to_test:
+                models_and_datasets.append(
+                    get_pytest_param_classifier(model_class, n_classes=n_classes)
+                )
+
+        else:
+            raise ValueError(  # pragma: no cover
+                f"Model class {model_class} is neither a regressor nor a classifier."
+            )
+
+    return models_and_datasets
+
+
+def get_sklearn_linear_models_and_datasets(
+    regressor: bool = True,
+    classifier: bool = True,
+    unique_models: bool = False,
+    include: Optional[Union[str, List[str]]] = None,
+    exclude: Optional[Union[str, List[str]]] = None,
+) -> List:
+    """Get the pytest parameters to use for testing linear models.
+
+    Args:
+        regressor (bool): If regressors should be selected.
+        classifier (bool): If classifiers should be selected.
+        unique_models (bool): If each models should be represented only once.
+        include (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+            a part of it) match the given string or list of strings. Default to None.
+        exclude (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+            a part of it) do not match the given string or list of strings. Default to None.
+
+    Returns:
+        List: The pytest parameters to use for testing linear models.
+    """
+
+    # Get all linear model classes currently available in Concrete ML
+    linear_classes = get_sklearn_linear_models(
+        regressor=regressor,
+        classifier=classifier,
+        str_in_class_name=include,
+        str_not_in_class_name=exclude,
+    )
+
+    # If the TweedieRegressor has been selected and is allowed to be represented more than once,
+    # add a few more testing configuration
+    if not unique_models and is_model_class_in_a_list(TweedieRegressor, linear_classes):
+        linear_classes += [
+            partial(TweedieRegressor, link="auto", power=0.0),
+            partial(TweedieRegressor, link="auto", power=2.8),
+            partial(TweedieRegressor, link="log", power=1.0),
+            partial(TweedieRegressor, link="identity", power=0.0),
+        ]
+
+    return _get_sklearn_models_and_datasets(linear_classes, unique_models=unique_models)
+
+
+def get_sklearn_tree_models_and_datasets(
+    regressor: bool = True,
+    classifier: bool = True,
+    unique_models: bool = False,
+    include: Optional[Union[str, List[str]]] = None,
+    exclude: Optional[Union[str, List[str]]] = None,
+) -> List:
+    """Get the pytest parameters to use for testing tree-based models.
+
+    Args:
+        regressor (bool): If regressors should be selected.
+        classifier (bool): If classifiers should be selected.
+        unique_models (bool): If each models should be represented only once.
+        include (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+            a part of it) match the given string or list of strings. Default to None.
+        exclude (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+            a part of it) do not match the given string or list of strings. Default to None.
+
+    Returns:
+        List: The pytest parameters to use for testing tree-based models.
+    """
+    # Get all tree-based model classes currently available in Concrete ML
+    tree_classes = get_sklearn_tree_models(
+        regressor=regressor,
+        classifier=classifier,
+        str_in_class_name=include,
+        str_not_in_class_name=exclude,
+    )
+
+    return _get_sklearn_models_and_datasets(tree_classes, unique_models=unique_models)
+
+
+def get_sklearn_neural_net_models_and_datasets(
+    regressor: bool = True,
+    classifier: bool = True,
+    unique_models: bool = False,
+    include: Optional[Union[str, List[str]]] = None,
+    exclude: Optional[Union[str, List[str]]] = None,
+) -> List:
+    """Get the pytest parameters to use for testing neural network models.
+
+    Args:
+        regressor (bool): If regressors should be selected.
+        classifier (bool): If classifiers should be selected.
+        unique_models (bool): If each models should be represented only once.
+        include (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+            a part of it) match the given string or list of strings. Default to None.
+        exclude (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+            a part of it) do not match the given string or list of strings. Default to None.
+
+    Returns:
+        List: The pytest parameters to use for testing neural network models.
+    """
+
+    # Get all neural-network model classes currently available in Concrete ML
+    selected_neural_net_classes = get_sklearn_neural_net_models(
+        regressor=regressor,
+        classifier=classifier,
+        str_in_class_name=include,
+        str_not_in_class_name=exclude,
+    )
+
+    neural_net_classes = []
+
+    # If the NeuralNetRegressor has been selected, configure its initialization parameters
+    if is_model_class_in_a_list(NeuralNetRegressor, selected_neural_net_classes):
+        neural_net_classes.append(
+            partial(
+                NeuralNetRegressor,
+                module__n_layers=3,
+                module__n_w_bits=2,
+                module__n_a_bits=2,
+                module__n_accum_bits=7,  # Stay with 7 bits for test exec time
+                module__n_hidden_neurons_multiplier=1,
+                module__activation_function=nn.ReLU,
+                max_epochs=10,
+                verbose=0,
+                callbacks="disable",
+            )
+        )
+
+    # If the NeuralNetClassifier has been selected, configure its initialization parameters
+    if is_model_class_in_a_list(NeuralNetClassifier, selected_neural_net_classes):
+        neural_net_classes.append(
+            partial(
+                NeuralNetClassifier,
+                module__n_layers=3,
+                module__activation_function=nn.ReLU,
+                max_epochs=10,
+                verbose=0,
+                callbacks="disable",
+            )
+        )
+    return _get_sklearn_models_and_datasets(neural_net_classes, unique_models=unique_models)
+
+
+def get_sklearn_neighbors_models_and_datasets(
+    regressor: bool = True,
+    classifier: bool = True,
+    unique_models: bool = False,
+    include: Optional[Union[str, List[str]]] = None,
+    exclude: Optional[Union[str, List[str]]] = None,
+) -> List:
+    """Get the pytest parameters to use for testing neighbor models.
+
+    Args:
+        regressor (bool): If regressors should be selected.
+        classifier (bool): If classifiers should be selected.
+        unique_models (bool): If each models should be represented only once.
+        include (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+            a part of it) match the given string or list of strings. Default to None.
+        exclude (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+            a part of it) do not match the given string or list of strings. Default to None.
+
+    Returns:
+        List: The pytest parameters to use for testing neighbor models.
+    """
+    # Get all neighbor model classes currently available in Concrete ML
+    neighbor_classes = get_sklearn_neighbors_models(
+        regressor=regressor,
+        classifier=classifier,
+        str_in_class_name=include,
+        str_not_in_class_name=exclude,
+    )
+
+    return _get_sklearn_models_and_datasets(neighbor_classes, unique_models=unique_models)
+
+
+def get_sklearn_all_models_and_datasets(
+    regressor: bool = True,
+    classifier: bool = True,
+    unique_models: bool = False,
+    include: Optional[Union[str, List[str]]] = None,
+    exclude: Optional[Union[str, List[str]]] = None,
+) -> List:
+    """Get the pytest parameters to use for testing all models available in Concrete ML.
+
+    Args:
+        regressor (bool): If regressors should be selected.
+        classifier (bool): If classifiers should be selected.
+        unique_models (bool): If each models should be represented only once.
+        include (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+            a part of it) match the given string or list of strings. Default to None.
+        exclude (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+            a part of it) do not match the given string or list of strings. Default to None.
+
+    Returns:
+        List: The pytest parameters to use for testing all models available in Concrete ML.
+    """
+    return (
+        get_sklearn_linear_models_and_datasets(
+            regressor=regressor,
+            classifier=classifier,
+            unique_models=unique_models,
+            include=include,
+            exclude=exclude,
+        )
+        + get_sklearn_tree_models_and_datasets(
+            regressor=regressor,
+            classifier=classifier,
+            unique_models=unique_models,
+            include=include,
+            exclude=exclude,
+        )
+        + get_sklearn_neural_net_models_and_datasets(
+            regressor=regressor,
+            classifier=classifier,
+            unique_models=unique_models,
+            include=include,
+            exclude=exclude,
+        )
+        + get_sklearn_neighbors_models_and_datasets(
+            regressor=regressor,
+            classifier=classifier,
+            unique_models=unique_models,
+            include=include,
+            exclude=exclude,
+        )
+    )
+
+
+# All scikit-learn models available in Concrete ML to test and their associated dataset parameters
+MODELS_AND_DATASETS = get_sklearn_all_models_and_datasets(regressor=True, classifier=True)
+
+# All unique scikit-learn models available in Concrete ML and their associated dataset parameters
+UNIQUE_MODELS_AND_DATASETS = get_sklearn_all_models_and_datasets(
+    regressor=True, classifier=True, unique_models=True
+)
 
 
 def instantiate_model_generic(model_class, n_bits, **parameters):

--- a/src/concrete/ml/search_parameters/p_error_search.py
+++ b/src/concrete/ml/search_parameters/p_error_search.py
@@ -61,11 +61,7 @@ import torch
 from tqdm import tqdm
 
 from ..common.utils import is_brevitas_model, is_model_class_in_a_list
-from ..sklearn import (
-    get_sklearn_neighbors_models,
-    get_sklearn_neural_net_models,
-    get_sklearn_tree_models,
-)
+from ..sklearn import _get_sklearn_all_models, _get_sklearn_linear_models
 from ..torch.compile import compile_brevitas_qat_model, compile_torch_model
 
 
@@ -130,11 +126,8 @@ def compile_and_simulated_fhe_inference(
         dequantized_output = quantized_module.forward(calibration_data, fhe="simulate")
 
     elif is_model_class_in_a_list(
-        estimator,
-        get_sklearn_neural_net_models()
-        + get_sklearn_tree_models()
-        + get_sklearn_neighbors_models(),
-    ):
+        estimator, _get_sklearn_all_models()
+    ) and not is_model_class_in_a_list(estimator, _get_sklearn_linear_models()):
         if not estimator.is_fitted:
             estimator.fit(calibration_data, ground_truth)
 

--- a/src/concrete/ml/sklearn/__init__.py
+++ b/src/concrete/ml/sklearn/__init__.py
@@ -24,7 +24,7 @@ from .tree import DecisionTreeClassifier, DecisionTreeRegressor
 from .xgb import XGBClassifier, XGBRegressor
 
 
-def get_sklearn_models() -> Dict[str, List]:
+def _get_sklearn_models() -> Dict[str, List]:
     """Return the list of available scikit-learn models in Concrete ML.
 
     Returns:
@@ -51,8 +51,8 @@ def _filter_models(
     models,
     classifier: bool = True,
     regressor: bool = True,
-    include: Optional[Union[str, List[str]]] = None,
-    exclude: Optional[Union[str, List[str]]] = None,
+    select: Optional[Union[str, List[str]]] = None,
+    ignore: Optional[Union[str, List[str]]] = None,
 ):
     """Return a list of models filtered by the given conditions, sorted by name.
 
@@ -60,9 +60,9 @@ def _filter_models(
         models: The list of models to consider.
         classifier (bool): If classifiers should be considered. Default to True.
         regressor (bool): If regressors should be considered. Default to True.
-        include (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+        select (Optional[Union[str, List[str]]]): If not None, only return models which names (or
             a part of it) match the given string or list of strings. Default to None.
-        exclude (Optional[Union[str, List[str]]]): If not None, only return models which names (or
+        ignore (Optional[Union[str, List[str]]]): If not None, only return models which names (or
             a part of it) do not match the given string or list of strings. Default to None.
 
     Returns:
@@ -79,25 +79,25 @@ def _filter_models(
     if regressor:
         selected_models += [model for model in models if is_regressor_or_partial_regressor(model)]
 
-    if include is not None:
-        if isinstance(include, str):
-            include = [include]
+    if select is not None:
+        if isinstance(select, str):
+            select = [select]
 
-        # Filter the selected models: only include the ones which name matches the given string
+        # Filter the selected models: only select the ones which name matches the given string
         # (or at least one of the given strings if it is a list)
         selected_models = [
-            model for name in include for model in selected_models if name in get_model_name(model)
+            model for name in select for model in selected_models if name in get_model_name(model)
         ]
 
-    if exclude is not None:
-        if isinstance(exclude, str):
-            exclude = [exclude]
+    if ignore is not None:
+        if isinstance(ignore, str):
+            ignore = [ignore]
 
         # Filter the selected models: remove the ones which name matches the given string (or at
         # least one of the given strings if it is a list)
         selected_models = [
             model
-            for name in exclude
+            for name in ignore
             for model in selected_models
             if name not in get_model_name(model)
         ]
@@ -106,11 +106,11 @@ def _filter_models(
     return sorted(selected_models, key=lambda m: m.__name__)
 
 
-def get_sklearn_linear_models(
+def _get_sklearn_linear_models(
     classifier: bool = True,
     regressor: bool = True,
-    str_in_class_name: Optional[Union[str, List[str]]] = None,
-    str_not_in_class_name: Optional[Union[str, List[str]]] = None,
+    select: Optional[Union[str, List[str]]] = None,
+    ignore: Optional[Union[str, List[str]]] = None,
 ):
     """Return a list of available linear models in Concrete ML.
 
@@ -119,30 +119,30 @@ def get_sklearn_linear_models(
     Args:
         classifier (bool): If classifiers should be considered. Default to True.
         regressor (bool): If regressors should be considered. Default to True.
-        str_in_class_name (Optional[Union[str, List[str]]]): If not None, only return models which
+        select (Optional[Union[str, List[str]]]): If not None, only return models which
             names (or a part of it) match the given string or list of strings. Default to None.
-        str_not_in_class_name (Optional[Union[str, List[str]]]): If not None, only return models
+        ignore (Optional[Union[str, List[str]]]): If not None, only return models
             which names (or a part of it) do not match the given string or list of strings. Default
             to None.
 
     Returns:
         The filtered list of linear models available in Concrete ML, sorted by name.
     """
-    linear_models = get_sklearn_models()["linear"]
+    linear_models = _get_sklearn_models()["linear"]
     return _filter_models(
         linear_models,
         classifier=classifier,
         regressor=regressor,
-        include=str_in_class_name,
-        exclude=str_not_in_class_name,
+        select=select,
+        ignore=ignore,
     )
 
 
-def get_sklearn_tree_models(
+def _get_sklearn_tree_models(
     classifier: bool = True,
     regressor: bool = True,
-    str_in_class_name: Optional[Union[str, List[str]]] = None,
-    str_not_in_class_name: Optional[Union[str, List[str]]] = None,
+    select: Optional[Union[str, List[str]]] = None,
+    ignore: Optional[Union[str, List[str]]] = None,
 ):
     """Return the list of available tree-based models in Concrete ML.
 
@@ -151,25 +151,23 @@ def get_sklearn_tree_models(
     Args:
         classifier (bool): If classifiers should be considered. Default to True.
         regressor (bool): If regressors should be considered. Default to True.
-        str_in_class_name (Union[str, List[str]]): If not None, only return models which names (or
+        select (Union[str, List[str]]): If not None, only return models which names (or
             a part of it) match the given string or list of strings. Default to None.
-        str_not_in_class_name (Union[str, List[str]]): If not None, only return models which names
+        ignore (Union[str, List[str]]): If not None, only return models which names
             (or a part of it) do not match the given string or list of strings. Default to None.
 
     Returns:
         The filtered list of tree-based models available in Concrete ML, sorted by name.
     """
-    tree_models = get_sklearn_models()["tree"]
-    return _filter_models(
-        tree_models, classifier, regressor, include=str_in_class_name, exclude=str_not_in_class_name
-    )
+    tree_models = _get_sklearn_models()["tree"]
+    return _filter_models(tree_models, classifier, regressor, select=select, ignore=ignore)
 
 
-def get_sklearn_neural_net_models(
+def _get_sklearn_neural_net_models(
     classifier: bool = True,
     regressor: bool = True,
-    str_in_class_name: Optional[Union[str, List[str]]] = None,
-    str_not_in_class_name: Optional[Union[str, List[str]]] = None,
+    select: Optional[Union[str, List[str]]] = None,
+    ignore: Optional[Union[str, List[str]]] = None,
 ):
     """Return the list of available neural network models in Concrete ML.
 
@@ -178,30 +176,30 @@ def get_sklearn_neural_net_models(
     Args:
         classifier (bool): If classifiers should be considered. Default to True.
         regressor (bool): If regressors should be considered. Default to True.
-        str_in_class_name (Optional[Union[str, List[str]]]): If not None, only return models which
+        select (Optional[Union[str, List[str]]]): If not None, only return models which
             names (or a part of it) match the given string or list of strings. Default to None.
-        str_not_in_class_name (Optional[Union[str, List[str]]]): If not None, only return models
+        ignore (Optional[Union[str, List[str]]]): If not None, only return models
             which names (or a part of it) do not match the given string or list of strings. Default
             to None.
 
     Returns:
         The filtered list of neural network models available in Concrete ML, sorted by name.
     """
-    neural_network_models = get_sklearn_models()["neural_net"]
+    neural_network_models = _get_sklearn_models()["neural_net"]
     return _filter_models(
         neural_network_models,
         classifier=classifier,
         regressor=regressor,
-        include=str_in_class_name,
-        exclude=str_not_in_class_name,
+        select=select,
+        ignore=ignore,
     )
 
 
-def get_sklearn_neighbors_models(
+def _get_sklearn_neighbors_models(
     classifier: bool = True,
     regressor: bool = True,
-    str_in_class_name: Optional[Union[str, List[str]]] = None,
-    str_not_in_class_name: Optional[Union[str, List[str]]] = None,
+    select: Optional[Union[str, List[str]]] = None,
+    ignore: Optional[Union[str, List[str]]] = None,
 ):
     """Return the list of available neighbor models in Concrete ML.
 
@@ -210,30 +208,30 @@ def get_sklearn_neighbors_models(
     Args:
         classifier (bool): If classifiers should be considered. Default to True.
         regressor (bool): If regressors should be considered. Default to True.
-        str_in_class_name (Optional[Union[str, List[str]]]): If not None, only return models which
+        select (Optional[Union[str, List[str]]]): If not None, only return models which
             names (or a part of it) match the given string or list of strings. Default to None.
-        str_not_in_class_name (Optional[Union[str, List[str]]]): If not None, only return models
+        ignore (Optional[Union[str, List[str]]]): If not None, only return models
             which names (or a part of it) do not match the given string or list of strings. Default
             to None.
 
     Returns:
         The filtered list of neighbor models available in Concrete ML, sorted by name.
     """
-    neighbor_models = get_sklearn_models()["neighbors"]
+    neighbor_models = _get_sklearn_models()["neighbors"]
     return _filter_models(
         neighbor_models,
         classifier=classifier,
         regressor=regressor,
-        include=str_in_class_name,
-        exclude=str_not_in_class_name,
+        select=select,
+        ignore=ignore,
     )
 
 
-def get_sklearn_all_models(
+def _get_sklearn_all_models(
     classifier: bool = True,
     regressor: bool = True,
-    str_in_class_name: Optional[Union[str, List[str]]] = None,
-    str_not_in_class_name: Optional[Union[str, List[str]]] = None,
+    select: Optional[Union[str, List[str]]] = None,
+    ignore: Optional[Union[str, List[str]]] = None,
 ):
     """Return the list of all available models in Concrete ML.
 
@@ -242,20 +240,20 @@ def get_sklearn_all_models(
     Args:
         classifier (bool): If classifiers should be considered.
         regressor (bool): If regressors should be considered.
-        str_in_class_name (Optional[Union[str, List[str]]]): If not None, only return models which
+        select (Optional[Union[str, List[str]]]): If not None, only return models which
             names (or a part of it) match the given string or list of strings. Default to None.
-        str_not_in_class_name (Optional[Union[str, List[str]]]): If not None, only return models
+        ignore (Optional[Union[str, List[str]]]): If not None, only return models
             which names (or a part of it) do not match the given string or list of strings. Default
             to None.
 
     Returns:
         The filtered list of all models available in Concrete ML, sorted by name.
     """
-    all_models = get_sklearn_models()["all"]
+    all_models = _get_sklearn_models()["all"]
     return _filter_models(
         all_models,
         classifier=classifier,
         regressor=regressor,
-        include=str_in_class_name,
-        exclude=str_not_in_class_name,
+        select=select,
+        ignore=ignore,
     )

--- a/src/concrete/ml/sklearn/base.py
+++ b/src/concrete/ml/sklearn/base.py
@@ -1,6 +1,7 @@
 """Base classes for all estimators."""
 from __future__ import annotations
 
+import copy
 import tempfile
 
 # Disable pylint as some names like X and q_X are used, following scikit-Learn's standard. The file
@@ -1515,7 +1516,7 @@ class SklearnLinearModelMixin(BaseEstimator, sklearn.base.BaseEstimator, ABC):
         model = cls(n_bits=n_bits, **init_params)
 
         # Update the underlying scikit-learn model with the given fitted one
-        model.sklearn_model = sklearn_model
+        model.sklearn_model = copy.deepcopy(sklearn_model)
 
         # Compute the quantization parameters
         return model._quantize_model(X)

--- a/tests/common/test_pbs_error_probability_settings.py
+++ b/tests/common/test_pbs_error_probability_settings.py
@@ -8,13 +8,13 @@ from sklearn.exceptions import ConvergenceWarning
 from torch import nn
 
 from concrete.ml.pytest.torch_models import FCSmall
-from concrete.ml.pytest.utils import sklearn_models_and_datasets
+from concrete.ml.pytest.utils import MODELS_AND_DATASETS
 from concrete.ml.torch.compile import compile_torch_model
 
 INPUT_OUTPUT_FEATURE = [5, 10]
 
 
-@pytest.mark.parametrize("model_class, parameters", sklearn_models_and_datasets)
+@pytest.mark.parametrize("model_class, parameters", MODELS_AND_DATASETS)
 @pytest.mark.parametrize(
     "kwargs",
     [

--- a/tests/common/test_serialization.py
+++ b/tests/common/test_serialization.py
@@ -34,8 +34,8 @@ from concrete.ml.pytest.utils import check_serialization, values_are_equal
 from concrete.ml.quantization import QuantizedModule
 from concrete.ml.sklearn import (
     LinearRegression,
+    get_sklearn_all_models,
     get_sklearn_linear_models,
-    get_sklearn_models,
     get_sklearn_tree_models,
 )
 
@@ -217,7 +217,7 @@ def test_serialize_numpy_array(dtype):
 # Test the most important types
 @pytest.mark.parametrize(
     "value",
-    SUPPORTED_TORCH_ACTIVATIONS + get_sklearn_models()["all"] + [QuantizedModule],
+    SUPPORTED_TORCH_ACTIVATIONS + get_sklearn_all_models() + [QuantizedModule],
 )
 def test_serialize_type(value):
     """Test serialization of type objects (trusted by Skops)."""

--- a/tests/common/test_serialization.py
+++ b/tests/common/test_serialization.py
@@ -34,9 +34,9 @@ from concrete.ml.pytest.utils import check_serialization, values_are_equal
 from concrete.ml.quantization import QuantizedModule
 from concrete.ml.sklearn import (
     LinearRegression,
-    get_sklearn_all_models,
-    get_sklearn_linear_models,
-    get_sklearn_tree_models,
+    _get_sklearn_all_models,
+    _get_sklearn_linear_models,
+    _get_sklearn_tree_models,
 )
 
 
@@ -112,7 +112,7 @@ def test_serialize_random_state(random_state, random_state_type):
 
 @pytest.mark.parametrize(
     "concrete_model_class",
-    get_sklearn_linear_models() + get_sklearn_tree_models(),
+    _get_sklearn_linear_models() + _get_sklearn_tree_models(),
 )
 def test_serialize_sklearn_model(concrete_model_class, load_data):
     """Test serialization of sklearn_model objects."""
@@ -217,7 +217,7 @@ def test_serialize_numpy_array(dtype):
 # Test the most important types
 @pytest.mark.parametrize(
     "value",
-    SUPPORTED_TORCH_ACTIVATIONS + get_sklearn_all_models() + [QuantizedModule],
+    SUPPORTED_TORCH_ACTIVATIONS + _get_sklearn_all_models() + [QuantizedModule],
 )
 def test_serialize_type(value):
     """Test serialization of type objects (trusted by Skops)."""

--- a/tests/common/test_skearn_model_lists.py
+++ b/tests/common/test_skearn_model_lists.py
@@ -1,5 +1,12 @@
 """Tests lists of models in Concrete ML."""
-from concrete.ml.sklearn import get_sklearn_models
+from concrete.ml.pytest.utils import MODELS_AND_DATASETS, UNIQUE_MODELS_AND_DATASETS
+from concrete.ml.sklearn import (
+    get_sklearn_all_models,
+    get_sklearn_linear_models,
+    get_sklearn_neighbors_models,
+    get_sklearn_neural_net_models,
+    get_sklearn_tree_models,
+)
 from concrete.ml.sklearn.glm import GammaRegressor, PoissonRegressor, TweedieRegressor
 from concrete.ml.sklearn.linear_model import (
     ElasticNet,
@@ -18,41 +25,39 @@ from concrete.ml.sklearn.xgb import XGBClassifier, XGBRegressor
 
 def test_get_sklearn_models():
     """List all available models in Concrete ML."""
-    dic = get_sklearn_models()
-
-    cml_list = dic["all"]
-    linear_list = dic["linear"]
-    tree_list = dic["tree"]
-    neuralnet_list = dic["neural_net"]
-    neighbors_list = dic["neighbors"]
+    all_models = get_sklearn_all_models()
+    linear_models = get_sklearn_linear_models()
+    tree_models = get_sklearn_tree_models()
+    neural_network_models = get_sklearn_neural_net_models()
+    neighbor_models = get_sklearn_neighbors_models()
 
     print("All models: ")
-    for m in cml_list:
+    for m in all_models:
         print(f"     {m}")
 
     print("Linear models: ")
-    for m in linear_list:
+    for m in linear_models:
         print(f"     {m}")
 
     print("Tree models: ")
-    for m in tree_list:
+    for m in tree_models:
         print(f"     {m}")
 
     print("Neural net models: ")
-    for m in neuralnet_list:
+    for m in neural_network_models:
         print(f"     {m}")
 
     print("Neighbors models: ")
-    for m in neighbors_list:
+    for m in neighbor_models:
         print(f"     {m}")
 
     # Check values
-    expected_neuralnet_list = [NeuralNetClassifier, NeuralNetRegressor]
+    expected_neural_network_models = [NeuralNetClassifier, NeuralNetRegressor]
     assert (
-        neuralnet_list == expected_neuralnet_list
-    ), "Please change the expected number of models if you add new models"
+        neural_network_models == expected_neural_network_models
+    ), "Please change the expected number of models if new models have been added"
 
-    expected_tree_list = [
+    expected_tree_models = [
         DecisionTreeClassifier,
         DecisionTreeRegressor,
         RandomForestClassifier,
@@ -61,10 +66,10 @@ def test_get_sklearn_models():
         XGBRegressor,
     ]
     assert (
-        tree_list == expected_tree_list
-    ), "Please change the expected number of models if you add new models"
+        tree_models == expected_tree_models
+    ), "Please change the expected number of models if new models have been added"
 
-    expected_linear_list = [
+    expected_linear_models = [
         ElasticNet,
         GammaRegressor,
         Lasso,
@@ -77,17 +82,24 @@ def test_get_sklearn_models():
         TweedieRegressor,
     ]
 
-    expected_neighbors_list = [KNeighborsClassifier]
+    expected_neighbor_models = [KNeighborsClassifier]
 
     assert (
-        linear_list == expected_linear_list
-    ), "Please change the expected number of models if you add new models"
+        linear_models == expected_linear_models
+    ), "Please change the expected number of models if new models have been added"
 
     # Check number
-    assert cml_list == sorted(
-        expected_linear_list
-        + expected_neuralnet_list
-        + expected_tree_list
-        + expected_neighbors_list,
+    assert all_models == sorted(
+        expected_linear_models
+        + expected_tree_models
+        + expected_neural_network_models
+        + expected_neighbor_models,
         key=lambda m: m.__name__,
-    ), "Please change the expected number of models if you add new models"
+    ), "Please change the expected number of models if new models have been added"
+
+
+def test_models_and_datasets():
+    """Check that the tested model's configuration lists remain fixed."""
+
+    assert len(MODELS_AND_DATASETS) == 29
+    assert len(UNIQUE_MODELS_AND_DATASETS) == 19

--- a/tests/common/test_skearn_model_lists.py
+++ b/tests/common/test_skearn_model_lists.py
@@ -1,11 +1,11 @@
 """Tests lists of models in Concrete ML."""
 from concrete.ml.pytest.utils import MODELS_AND_DATASETS, UNIQUE_MODELS_AND_DATASETS
 from concrete.ml.sklearn import (
-    get_sklearn_all_models,
-    get_sklearn_linear_models,
-    get_sklearn_neighbors_models,
-    get_sklearn_neural_net_models,
-    get_sklearn_tree_models,
+    _get_sklearn_all_models,
+    _get_sklearn_linear_models,
+    _get_sklearn_neighbors_models,
+    _get_sklearn_neural_net_models,
+    _get_sklearn_tree_models,
 )
 from concrete.ml.sklearn.glm import GammaRegressor, PoissonRegressor, TweedieRegressor
 from concrete.ml.sklearn.linear_model import (
@@ -25,11 +25,11 @@ from concrete.ml.sklearn.xgb import XGBClassifier, XGBRegressor
 
 def test_get_sklearn_models():
     """List all available models in Concrete ML."""
-    all_models = get_sklearn_all_models()
-    linear_models = get_sklearn_linear_models()
-    tree_models = get_sklearn_tree_models()
-    neural_network_models = get_sklearn_neural_net_models()
-    neighbor_models = get_sklearn_neighbors_models()
+    all_models = _get_sklearn_all_models()
+    linear_models = _get_sklearn_linear_models()
+    tree_models = _get_sklearn_tree_models()
+    neural_network_models = _get_sklearn_neural_net_models()
+    neighbor_models = _get_sklearn_neighbors_models()
 
     print("All models: ")
     for m in all_models:

--- a/tests/deployment/test_client_server.py
+++ b/tests/deployment/test_client_server.py
@@ -14,11 +14,7 @@ from torch import nn
 
 from concrete.ml.deployment.fhe_client_server import FHEModelClient, FHEModelDev, FHEModelServer
 from concrete.ml.pytest.torch_models import FCSmall
-from concrete.ml.pytest.utils import (
-    get_model_name,
-    instantiate_model_generic,
-    sklearn_models_and_datasets,
-)
+from concrete.ml.pytest.utils import MODELS_AND_DATASETS, get_model_name, instantiate_model_generic
 from concrete.ml.quantization.quantized_module import QuantizedModule
 from concrete.ml.torch.compile import compile_torch_model
 
@@ -70,7 +66,7 @@ class OnDiskNetwork:
         self.dev_dir.cleanup()
 
 
-@pytest.mark.parametrize("model_class, parameters", sklearn_models_and_datasets)
+@pytest.mark.parametrize("model_class, parameters", MODELS_AND_DATASETS)
 @pytest.mark.parametrize("n_bits", [2])
 def test_client_server_sklearn(
     default_configuration,

--- a/tests/parameter_search/test_p_error_binary_search.py
+++ b/tests/parameter_search/test_p_error_binary_search.py
@@ -20,8 +20,8 @@ from concrete.ml.common.utils import (
 )
 from concrete.ml.pytest.torch_models import QuantCustomModel, TorchCustomModel
 from concrete.ml.pytest.utils import (
+    UNIQUE_MODELS_AND_DATASETS,
     data_calibration_processing,
-    get_random_extract_of_sklearn_models_and_datasets,
     instantiate_model_generic,
     load_torch_model,
 )
@@ -135,9 +135,7 @@ def test_update_valid_attr_method(attr, value, model_name, quant_type, metric, l
     assert getattr(search, attr) == value
 
 
-@pytest.mark.parametrize(
-    "model_class, parameters", get_random_extract_of_sklearn_models_and_datasets()
-)
+@pytest.mark.parametrize("model_class, parameters", UNIQUE_MODELS_AND_DATASETS)
 def test_non_convergence_for_built_in_models(model_class, parameters, load_data, is_weekly_option):
     """Check that binary search raises a user warning when convergence is not achieved.
 
@@ -293,9 +291,7 @@ def test_binary_search_for_custom_models(model_name, quant_type, threshold):
 
 
 @pytest.mark.parametrize("threshold", [0.02])
-@pytest.mark.parametrize(
-    "model_class, parameters", get_random_extract_of_sklearn_models_and_datasets()
-)
+@pytest.mark.parametrize("model_class, parameters", UNIQUE_MODELS_AND_DATASETS)
 @pytest.mark.parametrize("predict", ["predict", "predict_proba"])
 def test_binary_search_for_built_in_models(model_class, parameters, threshold, predict, load_data):
     """Check if the returned `p_error` is valid for built-in models."""
@@ -388,9 +384,7 @@ def test_invalid_estimator_for_custom_models(is_qat, load_data):
         search.run(x=x_calib, ground_truth=y, strategy=all, max_iter=1, n_simulation=1)
 
 
-@pytest.mark.parametrize(
-    "model_class, parameters", get_random_extract_of_sklearn_models_and_datasets()
-)
+@pytest.mark.parametrize("model_class, parameters", UNIQUE_MODELS_AND_DATASETS)
 def test_invalid_estimator_for_built_in_models(model_class, parameters, load_data):
     """Check that binary search raises an exception for unsupported models."""
 

--- a/tests/seeding/test_seeding.py
+++ b/tests/seeding/test_seeding.py
@@ -8,7 +8,7 @@ import pytest
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.tree import plot_tree
 
-from concrete.ml.pytest.utils import sklearn_models_and_datasets
+from concrete.ml.pytest.utils import MODELS_AND_DATASETS
 
 
 def test_seed_1():
@@ -79,7 +79,7 @@ def test_seed_needing_randomly_seed_arg_3(random_inputs_1, random_inputs_2, rand
     print("Random inputs", random_inputs_3)
 
 
-@pytest.mark.parametrize("model_class, parameters", sklearn_models_and_datasets)
+@pytest.mark.parametrize("model_class, parameters", MODELS_AND_DATASETS)
 def test_seed_sklearn(model_class, parameters, load_data, default_configuration):
     """Test seeding of sklearn models"""
 

--- a/tests/sklearn/test_common.py
+++ b/tests/sklearn/test_common.py
@@ -7,7 +7,7 @@ import pytest
 from sklearn.exceptions import ConvergenceWarning
 
 from concrete.ml.common.utils import get_model_class
-from concrete.ml.pytest.utils import sklearn_models_and_datasets
+from concrete.ml.pytest.utils import MODELS_AND_DATASETS
 from concrete.ml.sklearn import (
     get_sklearn_linear_models,
     get_sklearn_neighbors_models,
@@ -39,7 +39,7 @@ def test_sklearn_args():
     assert test_counter == 19
 
 
-@pytest.mark.parametrize("model_class, parameters", sklearn_models_and_datasets)
+@pytest.mark.parametrize("model_class, parameters", MODELS_AND_DATASETS)
 def test_seed_sklearn(model_class, parameters, load_data):
     """Tests the random_state parameter."""
     x, y = load_data(model_class, **parameters)

--- a/tests/sklearn/test_common.py
+++ b/tests/sklearn/test_common.py
@@ -8,23 +8,13 @@ from sklearn.exceptions import ConvergenceWarning
 
 from concrete.ml.common.utils import get_model_class
 from concrete.ml.pytest.utils import MODELS_AND_DATASETS
-from concrete.ml.sklearn import (
-    get_sklearn_linear_models,
-    get_sklearn_neighbors_models,
-    get_sklearn_neural_net_models,
-    get_sklearn_tree_models,
-)
+from concrete.ml.sklearn import _get_sklearn_all_models
 
 
 def test_sklearn_args():
     """Check that all arguments from the underlying sklearn model are exposed."""
     test_counter = 0
-    for model_class in (
-        get_sklearn_linear_models()
-        + get_sklearn_neural_net_models()
-        + get_sklearn_tree_models()
-        + get_sklearn_neighbors_models()
-    ):
+    for model_class in _get_sklearn_all_models():
         model_class = get_model_class(model_class)
 
         # For Neural Network models, we manually fix the module parameter to

--- a/tests/sklearn/test_dump_onnx.py
+++ b/tests/sklearn/test_dump_onnx.py
@@ -10,7 +10,7 @@ import pytest
 from sklearn.exceptions import ConvergenceWarning
 
 from concrete.ml.common.utils import is_model_class_in_a_list
-from concrete.ml.pytest.utils import MODELS_AND_DATASETS, get_model_name
+from concrete.ml.pytest.utils import UNIQUE_MODELS_AND_DATASETS, get_model_name
 from concrete.ml.sklearn import get_sklearn_tree_models
 from concrete.ml.sklearn.qnn import NeuralNetClassifier, NeuralNetRegressor
 
@@ -71,6 +71,7 @@ def check_onnx_file_dump(model_class, parameters, load_data, str_expected, defau
     print(str_model)
 
     # Test equality when it does not depend on seeds
+    # FIXME: https://github.com/zama-ai/concrete-ml-internal/issues/3266
     if not is_model_class_in_a_list(
         model_class, get_sklearn_tree_models(str_in_class_name="RandomForest")
     ):
@@ -84,7 +85,7 @@ def check_onnx_file_dump(model_class, parameters, load_data, str_expected, defau
             assert str_model in str_expected
 
 
-@pytest.mark.parametrize("model_class, parameters", MODELS_AND_DATASETS)
+@pytest.mark.parametrize("model_class, parameters", UNIQUE_MODELS_AND_DATASETS)
 def test_dump(
     model_class,
     parameters,
@@ -216,16 +217,12 @@ def test_dump(
 ) {
   %/_operators.0/Gemm_output_0 = Gemm[alpha = 1, beta = 0, transB = 1](%_operators.0.weight_1, %input_0)
   %/_operators.0/LessOrEqual_output_0 = LessOrEqual(%/_operators.0/Gemm_output_0, %_operators.0.bias_1)
-  %/_operators.0/Constant_output_0 = Constant[value = <Tensor>]()
   %/_operators.0/Reshape_output_0 = Reshape[allowzero = 0](%/_operators.0/LessOrEqual_output_0, %/_operators.0/Constant_output_0)
   %/_operators.0/MatMul_output_0 = MatMul(%_operators.0.weight_2, %/_operators.0/Reshape_output_0)
-  %/_operators.0/Constant_1_output_0 = Constant[value = <Tensor>]()
   %/_operators.0/Reshape_1_output_0 = Reshape[allowzero = 0](%/_operators.0/MatMul_output_0, %/_operators.0/Constant_1_output_0)
   %/_operators.0/Equal_output_0 = Equal(%_operators.0.bias_2, %/_operators.0/Reshape_1_output_0)
-  %/_operators.0/Constant_2_output_0 = Constant[value = <Tensor>]()
   %/_operators.0/Reshape_2_output_0 = Reshape[allowzero = 0](%/_operators.0/Equal_output_0, %/_operators.0/Constant_2_output_0)
   %/_operators.0/MatMul_1_output_0 = MatMul(%_operators.0.weight_3, %/_operators.0/Reshape_2_output_0)
-  %/_operators.0/Constant_3_output_0 = Constant[value = <Tensor>]()
   %/_operators.0/Reshape_3_output_0 = Reshape[allowzero = 0](%/_operators.0/MatMul_1_output_0, %/_operators.0/Constant_3_output_0)
   %transposed_output = Transpose[perm = [2, 1, 0]](%/_operators.0/Reshape_3_output_0)
   return %transposed_output
@@ -292,16 +289,12 @@ def test_dump(
 ) {
   %/_operators.0/Gemm_output_0 = Gemm[alpha = 1, beta = 0, transB = 1](%_operators.0.weight_1, %input_0)
   %/_operators.0/LessOrEqual_output_0 = LessOrEqual(%/_operators.0/Gemm_output_0, %_operators.0.bias_1)
-  %/_operators.0/Constant_output_0 = Constant[value = <Tensor>]()
   %/_operators.0/Reshape_output_0 = Reshape[allowzero = 0](%/_operators.0/LessOrEqual_output_0, %/_operators.0/Constant_output_0)
   %/_operators.0/MatMul_output_0 = MatMul(%_operators.0.weight_2, %/_operators.0/Reshape_output_0)
-  %/_operators.0/Constant_1_output_0 = Constant[value = <Tensor>]()
   %/_operators.0/Reshape_1_output_0 = Reshape[allowzero = 0](%/_operators.0/MatMul_output_0, %/_operators.0/Constant_1_output_0)
   %/_operators.0/Equal_output_0 = Equal(%_operators.0.bias_2, %/_operators.0/Reshape_1_output_0)
-  %/_operators.0/Constant_2_output_0 = Constant[value = <Tensor>]()
   %/_operators.0/Reshape_2_output_0 = Reshape[allowzero = 0](%/_operators.0/Equal_output_0, %/_operators.0/Constant_2_output_0)
   %/_operators.0/MatMul_1_output_0 = MatMul(%_operators.0.weight_3, %/_operators.0/Reshape_2_output_0)
-  %/_operators.0/Constant_3_output_0 = Constant[value = <Tensor>]()
   %/_operators.0/Reshape_3_output_0 = Reshape[allowzero = 0](%/_operators.0/MatMul_1_output_0, %/_operators.0/Constant_3_output_0)
   %transposed_output = Transpose[perm = [2, 1, 0]](%/_operators.0/Reshape_3_output_0)
   return %transposed_output
@@ -338,20 +331,15 @@ def test_dump(
 ) {
   %/_operators.0/Gemm_output_0 = Gemm[alpha = 1, beta = 0, transB = 1](%_operators.0.weight_1, %input_0)
   %/_operators.0/Less_output_0 = Less(%/_operators.0/Gemm_output_0, %_operators.0.bias_1)
-  %/_operators.0/Constant_output_0 = Constant[value = <Tensor>]()
   %/_operators.0/Reshape_output_0 = Reshape[allowzero = 0](%/_operators.0/Less_output_0, %/_operators.0/Constant_output_0)
   %/_operators.0/MatMul_output_0 = MatMul(%_operators.0.weight_2, %/_operators.0/Reshape_output_0)
-  %/_operators.0/Constant_1_output_0 = Constant[value = <Tensor>]()
   %/_operators.0/Reshape_1_output_0 = Reshape[allowzero = 0](%/_operators.0/MatMul_output_0, %/_operators.0/Constant_1_output_0)
   %/_operators.0/Equal_output_0 = Equal(%_operators.0.bias_2, %/_operators.0/Reshape_1_output_0)
-  %/_operators.0/Constant_2_output_0 = Constant[value = <Tensor>]()
   %/_operators.0/Reshape_2_output_0 = Reshape[allowzero = 0](%/_operators.0/Equal_output_0, %/_operators.0/Constant_2_output_0)
   %/_operators.0/MatMul_1_output_0 = MatMul(%_operators.0.weight_3, %/_operators.0/Reshape_2_output_0)
-  %/_operators.0/Constant_3_output_0 = Constant[value = <Tensor>]()
   %/_operators.0/Reshape_3_output_0 = Reshape[allowzero = 0](%/_operators.0/MatMul_1_output_0, %/_operators.0/Constant_3_output_0)
   %/_operators.0/Squeeze_output_0 = Squeeze(%/_operators.0/Reshape_3_output_0, %axes_squeeze)
   %/_operators.0/Transpose_output_0 = Transpose[perm = [1, 0]](%/_operators.0/Squeeze_output_0)
-  %/_operators.0/Constant_4_output_0 = Constant[value = <Tensor>]()
   %/_operators.0/Reshape_4_output_0 = Reshape[allowzero = 0](%/_operators.0/Transpose_output_0, %/_operators.0/Constant_4_output_0)
   return %/_operators.0/Reshape_4_output_0
 }""",
@@ -377,30 +365,29 @@ def test_dump(
         "XGBRegressor": """graph torch_jit (
   %input_0[DOUBLE, symx10]
 ) initializers (
-  %_operators.0.base_prediction[INT64, 1]
   %_operators.0.weight_1[INT64, 140x10]
   %_operators.0.bias_1[INT64, 140x1]
   %_operators.0.weight_2[INT64, 20x8x7]
   %_operators.0.bias_2[INT64, 160x1]
   %_operators.0.weight_3[INT64, 20x1x8]
   %axes_squeeze[INT64, 1]
+  %/_operators.0/Constant_output_0[INT64, 3]
+  %/_operators.0/Constant_1_output_0[INT64, 2]
+  %/_operators.0/Constant_2_output_0[INT64, 3]
+  %/_operators.0/Constant_3_output_0[INT64, 3]
+  %/_operators.0/Constant_4_output_0[INT64, 3]
 ) {
   %/_operators.0/Gemm_output_0 = Gemm[alpha = 1, beta = 0, transB = 1](%_operators.0.weight_1, %input_0)
   %/_operators.0/Less_output_0 = Less(%/_operators.0/Gemm_output_0, %_operators.0.bias_1)
-  %/_operators.0/Constant_output_0 = Constant[value = <Tensor>]()
   %/_operators.0/Reshape_output_0 = Reshape[allowzero = 0](%/_operators.0/Less_output_0, %/_operators.0/Constant_output_0)
   %/_operators.0/MatMul_output_0 = MatMul(%_operators.0.weight_2, %/_operators.0/Reshape_output_0)
-  %/_operators.0/Constant_1_output_0 = Constant[value = <Tensor>]()
   %/_operators.0/Reshape_1_output_0 = Reshape[allowzero = 0](%/_operators.0/MatMul_output_0, %/_operators.0/Constant_1_output_0)
   %/_operators.0/Equal_output_0 = Equal(%_operators.0.bias_2, %/_operators.0/Reshape_1_output_0)
-  %/_operators.0/Constant_2_output_0 = Constant[value = <Tensor>]()
   %/_operators.0/Reshape_2_output_0 = Reshape[allowzero = 0](%/_operators.0/Equal_output_0, %/_operators.0/Constant_2_output_0)
   %/_operators.0/MatMul_1_output_0 = MatMul(%_operators.0.weight_3, %/_operators.0/Reshape_2_output_0)
-  %/_operators.0/Constant_3_output_0 = Constant[value = <Tensor>]()
   %/_operators.0/Reshape_3_output_0 = Reshape[allowzero = 0](%/_operators.0/MatMul_1_output_0, %/_operators.0/Constant_3_output_0)
   %/_operators.0/Squeeze_output_0 = Squeeze(%/_operators.0/Reshape_3_output_0, %axes_squeeze)
   %/_operators.0/Transpose_output_0 = Transpose[perm = [1, 0]](%/_operators.0/Squeeze_output_0)
-  %/_operators.0/Constant_4_output_0 = Constant[value = <Tensor>]()
   %/_operators.0/Reshape_4_output_0 = Reshape[allowzero = 0](%/_operators.0/Transpose_output_0, %/_operators.0/Constant_4_output_0)
   return %/_operators.0/Reshape_4_output_0
 }""",

--- a/tests/sklearn/test_dump_onnx.py
+++ b/tests/sklearn/test_dump_onnx.py
@@ -11,7 +11,7 @@ from sklearn.exceptions import ConvergenceWarning
 
 from concrete.ml.common.utils import is_model_class_in_a_list
 from concrete.ml.pytest.utils import UNIQUE_MODELS_AND_DATASETS, get_model_name
-from concrete.ml.sklearn import get_sklearn_tree_models
+from concrete.ml.sklearn import _get_sklearn_tree_models
 from concrete.ml.sklearn.qnn import NeuralNetClassifier, NeuralNetRegressor
 
 # Remark that the dump tests for torch module is directly done in test_compile_torch.py
@@ -72,9 +72,7 @@ def check_onnx_file_dump(model_class, parameters, load_data, str_expected, defau
 
     # Test equality when it does not depend on seeds
     # FIXME: https://github.com/zama-ai/concrete-ml-internal/issues/3266
-    if not is_model_class_in_a_list(
-        model_class, get_sklearn_tree_models(str_in_class_name="RandomForest")
-    ):
+    if not is_model_class_in_a_list(model_class, _get_sklearn_tree_models(select="RandomForest")):
         # The expected graph is usually a string and we therefore directly test if it is equal to
         # the retrieved graph's string. However, in some cases such as for TweedieRegressor models,
         # this graph can slightly changed depending on some input's values. We then expected the

--- a/tests/sklearn/test_dump_onnx.py
+++ b/tests/sklearn/test_dump_onnx.py
@@ -10,7 +10,7 @@ import pytest
 from sklearn.exceptions import ConvergenceWarning
 
 from concrete.ml.common.utils import is_model_class_in_a_list
-from concrete.ml.pytest.utils import get_model_name, sklearn_models_and_datasets
+from concrete.ml.pytest.utils import MODELS_AND_DATASETS, get_model_name
 from concrete.ml.sklearn import get_sklearn_tree_models
 from concrete.ml.sklearn.qnn import NeuralNetClassifier, NeuralNetRegressor
 
@@ -84,7 +84,7 @@ def check_onnx_file_dump(model_class, parameters, load_data, str_expected, defau
             assert str_model in str_expected
 
 
-@pytest.mark.parametrize("model_class, parameters", sklearn_models_and_datasets)
+@pytest.mark.parametrize("model_class, parameters", MODELS_AND_DATASETS)
 def test_dump(
     model_class,
     parameters,

--- a/tests/sklearn/test_pandas_errors.py
+++ b/tests/sklearn/test_pandas_errors.py
@@ -6,11 +6,10 @@ import pandas
 import pytest
 
 from concrete.ml.common.utils import is_model_class_in_a_list
-from concrete.ml.pytest.utils import sklearn_models_and_datasets
-from concrete.ml.sklearn import get_sklearn_neural_net_models
+from concrete.ml.sklearn import get_sklearn_all_models, get_sklearn_neural_net_models
 
 
-@pytest.mark.parametrize("model_class", [m[0][0] for m in sklearn_models_and_datasets])
+@pytest.mark.parametrize("model_class", get_sklearn_all_models())
 @pytest.mark.parametrize(
     "bad_value, expected_error",
     [

--- a/tests/sklearn/test_pandas_errors.py
+++ b/tests/sklearn/test_pandas_errors.py
@@ -5,11 +5,18 @@ import numpy
 import pandas
 import pytest
 
-from concrete.ml.common.utils import is_model_class_in_a_list
-from concrete.ml.sklearn import get_sklearn_all_models, get_sklearn_neural_net_models
+from concrete.ml.sklearn import (
+    _get_sklearn_linear_models,
+    _get_sklearn_neighbors_models,
+    _get_sklearn_tree_models,
+)
 
 
-@pytest.mark.parametrize("model_class", get_sklearn_all_models())
+# A type error will be raised for NeuralNetworks, which is tested in test_failure_bad_data_types
+@pytest.mark.parametrize(
+    "model_class",
+    _get_sklearn_linear_models() + _get_sklearn_tree_models() + _get_sklearn_neighbors_models(),
+)
 @pytest.mark.parametrize(
     "bad_value, expected_error",
     [
@@ -20,11 +27,6 @@ from concrete.ml.sklearn import get_sklearn_all_models, get_sklearn_neural_net_m
 )
 def test_failure_bad_param(model_class, bad_value, expected_error):
     """Check our checks see if ever the Pandas data-set is not correct."""
-
-    # For NeuralNetworks, a type error will be raised, which is tested
-    # in test_failure_bad_data_types
-    if is_model_class_in_a_list(model_class, get_sklearn_neural_net_models()):
-        return
 
     dic = {
         "Col One": [1, 2, bad_value, 3],

--- a/tests/sklearn/test_qnn.py
+++ b/tests/sklearn/test_qnn.py
@@ -19,12 +19,11 @@ from concrete.ml.common.utils import (
 )
 from concrete.ml.quantization.base_quantized_op import QuantizedMixingOp
 from concrete.ml.quantization.post_training import PowerOfTwoScalingRoundPBSAdapter
-from concrete.ml.sklearn import get_sklearn_neural_net_models
-from concrete.ml.sklearn.qnn import NeuralNetClassifier, NeuralNetRegressor
+from concrete.ml.sklearn import _get_sklearn_neural_net_models
 from concrete.ml.sklearn.qnn_module import SparseQuantNeuralNetwork
 
 
-@pytest.mark.parametrize("model_class", get_sklearn_neural_net_models())
+@pytest.mark.parametrize("model_class", _get_sklearn_neural_net_models())
 def test_parameter_validation(model_class, load_data):
     """Test that the sklearn quantized NN wrappers validate their parameters"""
 
@@ -121,7 +120,7 @@ def test_parameter_validation(model_class, load_data):
         pytest.param(nn.CELU),
     ],
 )
-@pytest.mark.parametrize("model_class", get_sklearn_neural_net_models())
+@pytest.mark.parametrize("model_class", _get_sklearn_neural_net_models())
 def test_compile_and_calib(
     activation_function,
     model_class,
@@ -237,37 +236,37 @@ def test_compile_and_calib(
     "model_classes, bad_types, expected_error",
     [
         pytest.param(
-            [NeuralNetClassifier],
+            _get_sklearn_neural_net_models(regressor=False, classifier=True),
             ("float32", "uint8"),
             "Neural Network classifier target dtype .* int64 .*",
             id="NeuralNetClassifier-target-uint8",
         ),
         pytest.param(
-            [NeuralNetRegressor],
+            _get_sklearn_neural_net_models(regressor=True, classifier=False),
             ("float64", "complex64"),
             "Neural Network regressor target dtype .* float32 .*",
             id="NeuralNetRegressor-target-complex64",
         ),
         pytest.param(
-            get_sklearn_neural_net_models(),
+            _get_sklearn_neural_net_models(),
             ("complex64", "int64"),
             "Neural Network .* input dtype .* float32 .*",
             id="NeuralNets-input-complex64",
         ),
         pytest.param(
-            get_sklearn_neural_net_models(),
+            _get_sklearn_neural_net_models(),
             ("int64", "int64"),
             "Neural Network .* input dtype .* float32 .*",
             id="NeuralNets-input-int64",
         ),
         pytest.param(
-            get_sklearn_neural_net_models(),
+            _get_sklearn_neural_net_models(),
             ("str", "int64"),
             "Neural Network .* input dtype .* float32 .*",
             id="NeuralNets-input-str",
         ),
         pytest.param(
-            get_sklearn_neural_net_models(),
+            _get_sklearn_neural_net_models(),
             ("float32", "str"),
             "Neural Network .* target dtype .* (float32|int64) .*",
             id="NeuralNets-target-str",
@@ -302,7 +301,7 @@ def test_failure_bad_data_types(model_classes, container, bad_types, expected_er
 
 
 @pytest.mark.parametrize("activation_function", [pytest.param(nn.ReLU)])
-@pytest.mark.parametrize("model_class", get_sklearn_neural_net_models())
+@pytest.mark.parametrize("model_class", _get_sklearn_neural_net_models())
 @pytest.mark.parametrize("accum_bits", [5, 8])
 def test_structured_pruning(
     activation_function, model_class, accum_bits, load_data, default_configuration
@@ -429,7 +428,7 @@ def test_structured_pruning(
     assert neurons_pruned[0] < neurons_orig[0]
 
 
-@pytest.mark.parametrize("model_class", get_sklearn_neural_net_models())
+@pytest.mark.parametrize("model_class", _get_sklearn_neural_net_models())
 @pytest.mark.parametrize(
     "unsupported_parameter, expected_error, expected_message",
     [
@@ -502,7 +501,9 @@ def test_serialization_unsupported_parameters(
     ],
 )
 @pytest.mark.parametrize("num_layers", [2, 4])
-@pytest.mark.parametrize("model_class", [NeuralNetClassifier])
+@pytest.mark.parametrize(
+    "model_class", _get_sklearn_neural_net_models(regressor=False, classifier=True)
+)
 @pytest.mark.parametrize("use_power_of_two_scaling", [True, False])
 def test_power_of_two_scaling(
     activation_function,

--- a/tests/sklearn/test_sklearn_models.py
+++ b/tests/sklearn/test_sklearn_models.py
@@ -63,7 +63,6 @@ from concrete.ml.pytest.utils import (
     get_sklearn_all_models_and_datasets,
     get_sklearn_linear_models_and_datasets,
     get_sklearn_neighbors_models_and_datasets,
-    get_sklearn_neural_net_models_and_datasets,
     get_sklearn_tree_models_and_datasets,
     instantiate_model_generic,
 )

--- a/tests/torch/test_brevitas_qat.py
+++ b/tests/torch/test_brevitas_qat.py
@@ -28,7 +28,7 @@ from concrete.ml.pytest.torch_models import (
 from concrete.ml.quantization.base_quantized_op import QuantizedMixingOp
 from concrete.ml.quantization.post_training import PowerOfTwoScalingRoundPBSAdapter
 from concrete.ml.quantization.qat_quantizers import Int8ActPerTensorPoT, Int8WeightPerTensorPoT
-from concrete.ml.sklearn import get_sklearn_neural_net_models
+from concrete.ml.sklearn import _get_sklearn_neural_net_models
 from concrete.ml.sklearn.qnn_module import SparseQuantNeuralNetwork
 from concrete.ml.torch.compile import compile_brevitas_qat_model
 
@@ -260,7 +260,7 @@ def test_brevitas_tinymnist_cnn(
 )
 @pytest.mark.parametrize("n_outputs", [5])
 @pytest.mark.parametrize("input_dim", [100])
-@pytest.mark.parametrize("model_class", get_sklearn_neural_net_models())
+@pytest.mark.parametrize("model_class", _get_sklearn_neural_net_models())
 @pytest.mark.parametrize("signed, narrow", [(True, False), (False, False), (True, True)])
 @pytest.mark.skip(reason="Torch dtype setting interferes with parallel test launch, and flaky test")
 def test_brevitas_intermediary_values(


### PR DESCRIPTION
Several things have been done here : 
- it's now possible to import fitted **linear** sklearn models in Concrete ML through the `.from_sklearn_model` method (name to be confirmed)
- test suite has been improved : 
     - it's easier to filter in/out models for tests (only consider linear models, exclude "DecistionTree" models, only consider "XGBClassifier", ect), instead of having to put "if ... then: return" (which made pytest and debuggers still display irrelevant test configurations)
     - `sklearn_models_and_datasets` has been replaced by `MODELS_AND_DATASETS` (more relevant)
     - `UNIQUE_MODELS_AND_DATASETS` replaced `get_random_extract_of_sklearn_models_and_datasets` (the function's name was misleading, as nothing was random + it's now easier to use)
     -  some tests run less configurations (by using `UNIQUE_MODELS_AND_DATASETS` instead of `MODELS_AND_DATASETS` , which considers a single config for each models, since some tests do not depend on the models' different init params). I might have missed more tests where this could be done as well (closing https://github.com/zama-ai/concrete-ml-internal/issues/3365 then)
     - fixed `_filter_models` which did not filter correctly by names : this lead to fixing the dump_onnx test for DT and XGB models
     - made all "get_slearkn_XXX_models" functions private

I did not expected this refactor to be that big, as I initially only wanted a way to easily get linear models only for my test. It probably would have been better to merge it in a dedicated PR before implementing the import feature. Anyway, I think it's still fine as the refactor mostly affects tests.

Also, we might want to add a small documentation about the new feature, so let me know what you think !

refs https://github.com/zama-ai/concrete-ml-internal/issues/4020
closes https://github.com/zama-ai/concrete-ml-internal/issues/3809
closes https://github.com/zama-ai/concrete-ml-internal/issues/3365