### PR TITLE
chore: add method to set fhe local mode of all remote modules

### DIFF
--- a/src/concrete/ml/torch/hybrid_model.py
+++ b/src/concrete/ml/torch/hybrid_model.py
@@ -528,3 +528,13 @@ class HybridFHEModel:
     def publish_to_hub(self):
         """Allow the user to push the model and FHE required files to HF Hub."""
         # TODO: implement HuggingFace model hub integration
+
+    def set_fhe_mode(self, hybrid_fhe_mode: Union[str, HybridFHEMode]):
+        """Set Hybrid FHE mode for all remote modules.
+
+        Args:
+            hybrid_fhe_mode (Union[str, HybridFHEMode]): Hybrid FHE mode to set to all
+                remote modules.
+        """
+        for module in self.remote_modules.values():
+            module.fhe_local_mode = HybridFHEMode(hybrid_fhe_mode)

--- a/tests/torch/test_hybrid_converter.py
+++ b/tests/torch/test_hybrid_converter.py
@@ -67,6 +67,7 @@ def run_hybrid_model_test(
 
         # Get the temp directory path
         hybrid_model.save_and_clear_private_info(temp_dir_path)
+        hybrid_model.set_fhe_mode("remote")
         # At this point, the hybrid model does not have
         # the parameters necessaryto run the module_names
 

--- a/use_case_examples/hybrid_model/infer_hybrid_llm_generate.py
+++ b/use_case_examples/hybrid_model/infer_hybrid_llm_generate.py
@@ -43,8 +43,7 @@ if __name__ == "__main__":
     )
     path_to_clients = Path(__file__).parent / "clients"
     hybrid_model.init_client(path_to_clients=path_to_clients)
-    for module in hybrid_model.remote_modules.values():
-        module.fhe_local_mode = HybridFHEMode.REMOTE
+    hybrid_model.set_fhe_mode(HybridFHEMode.REMOTE)
 
     # Run example
     while True:


### PR DESCRIPTION
Add a method to `HybridModel` to set the `fhe_local_mode` of all `RemoteModule`s at once.

closes https://github.com/zama-ai/concrete-ml-internal/issues/4000