### PR TITLE
chore: enable license action to install CP nightly versions

### DIFF
--- a/.github/workflows/update_licenses.yaml
+++ b/.github/workflows/update_licenses.yaml
@@ -20,6 +20,10 @@ jobs:
     defaults:
       run:
         shell: bash
+    env:
+      PIP_INDEX_URL: ${{ secrets.PIP_INDEX_URL }}
+      PIP_EXTRA_INDEX_URL: ${{ secrets.PIP_EXTRA_INDEX_URL }}
+
     steps:
       # Mask internal URLs if logged
       - name: Add masks


### PR DESCRIPTION
Without it, we are not able to tun the license action when using CP nightly versions