### PR TITLE
chore: add pull to license action

### DIFF
--- a/.github/workflows/update_licenses.yaml
+++ b/.github/workflows/update_licenses.yaml
@@ -53,6 +53,11 @@ jobs:
         run: |
           make licenses
       
+      # Pull the latest changes if there are some
+      - name: Pull latest changes
+        run: |
+          git pull -X theirs
+
       # If the target branch is main or a release branch, a pull request is opened for everyone to 
       # review
       - name: Open PR


### PR DESCRIPTION
Without it, only one of the two license update can be merged directly into a non-main / non-release branch using the action (ex: https://github.com/zama-ai/concrete-ml/actions/runs/6309990940/job/17131033599)