### PR TITLE
chore: add proper currency groups to GitHub actions

### DIFF
--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -7,7 +7,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.ref }}
+  group: "${{ github.ref }}-${{ github.event_name }}-${{ github.workflow }}"
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/refresh-notebooks.yaml
+++ b/.github/workflows/refresh-notebooks.yaml
@@ -3,8 +3,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
+  group: "${{ github.ref }}-${{ github.event_name }}-${{ github.workflow }}"
+  cancel-in-progress: false
 
 env:
   ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/refresh-one-notebook.yaml
+++ b/.github/workflows/refresh-one-notebook.yaml
@@ -42,7 +42,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.ref }}
+  group: "${{ github.ref }}-${{ github.event_name }}-${{ github.workflow }}"
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ on:
       - 'docs/developer-guide/api/**'
 
 concurrency:
-  group: ${{ github.ref }}
+  group: "${{ github.ref }}-${{ github.event_name }}-${{ github.workflow }}"
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/update_licenses.yaml
+++ b/.github/workflows/update_licenses.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.ref }}
+  group: "${{ github.ref }}-${{ github.event_name }}-${{ github.workflow }}"
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
without this, these actions would basically wait for each others before being launch as they were put in the same concurrency group (which created some issues like having the `prepare_release` action wait for the `refresh_one_notebook` action before running) cc @fd0r 