### PR TITLE
chore: fix concurrency group in release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,9 +18,16 @@ on:
       - src/concrete/ml/version.py
       - 'docs/developer-guide/api/**'
 
+# We need to make sure that the concurrency group is not identical to the continuous-integration.yaml
+# one, else the release workflow will be canceled when calling that latter for tests. More 
+# specifically, we should avoid using the usual "${{ github.ref }}-${{ github.event_name }}-${{ github.workflow }}"
+# group as the 'github.workflow' reference is shared between caller and called workflows, making
+# both workflows have the same concurrency group. Note that the problem happens because 
+# the continuous-integration.yaml workflow currently cancels all workflows from the same group that
+# are not triggered by a push targeting main, which is the case in the release process
 concurrency:
-  group: "${{ github.ref }}-${{ github.event_name }}-${{ github.workflow }}"
-  cancel-in-progress: false
+  group: "Release"
+  cancel-in-progress: true
 
 env:
   ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -216,7 +223,7 @@ jobs:
         run: |
           ./script/actions_utils/check_branch_not_remote.sh --branch_name "${{ env.RELEASE_BRANCH_NAME }}"
 
-  # The caller workflow's job (here 'release-tests') do not need to run on the current runner as 
+  # The caller workflow's job (here 'release-tests') does not need to run on the current runner as 
   # the reusable workflow (here 'continuous-integration.yaml') uses its own runner
   release-tests:
     name: Run tests


### PR DESCRIPTION
So basically, I recently changed concurrency groups in workflows to make sure they have unique references using `group: "${{ github.ref }}-${{ github.event_name }}-${{ github.workflow }}"` . Turns out, it's not well supported when using reusable workflow.  

Basically, `github.workflow` are made the same between the called and caller workflows (source: https://docs.github.com/en/actions/using-workflows/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow). This made the test CI workflow cancel the release workflow since they both share the same group ref but the CI one cancels all previous runs in progress when not triggered by a push on main (https://github.com/zama-ai/concrete-ml/blob/1516ee25024f618b01ee047efac332544cb25358/.github/workflows/continuous-integration.yaml#L75C3-L75C3)

I therefore made the release workflow group different (by just calling it "release") and I believe this should solve the problem. Also, I made sure that running a new release process actually cancels all other ones in progress (this makes sure we only have one release process at a time)

Another solution could have been to make the CI not cancel any workflows when triggered by a `workflow_dispatch` with `manual_call` and `release` as inputs. But I believe this is a bit more verbose and less comprehensible