### PR TITLE
chore: fix condition evalution for steps in release action

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -483,7 +483,7 @@ jobs:
       - name: Get all changed files from main in PR
         id: changed-files-in-pr
         if: | 
-          env.IS_PR
+          fromJSON(env.IS_PR)
           && steps.install-deps.outcome == 'success'
           && steps.make-pcc.outcome == 'success' 
           && !cancelled()
@@ -705,7 +705,7 @@ jobs:
       # comment is published in the PR and all flaky tests that initially failed are listed
       - name: Warn PR with flaky tests
         uses: marocchino/sticky-pull-request-comment@efaaab3fd41a9c3de579aba759d2552635e590fd
-        if: steps.pytest_regular.outcome == 'success' && env.FAILED_TESTS_ARE_FLAKY && !cancelled()
+        if: steps.pytest_regular.outcome == 'success' && fromJSON(env.FAILED_TESTS_ARE_FLAKY) && !cancelled()
         with:
           header: flaky-test
           recreate: true


### PR DESCRIPTION
without this, the "changed files" step would be run even for non-PR CIs