### PR TITLE
chore: update packages used in tests with pypi

### DIFF
--- a/script/make_utils/pytest_pypi_cml.sh
+++ b/script/make_utils/pytest_pypi_cml.sh
@@ -51,11 +51,11 @@ source "${PYPI_VENV}/bin/activate"
 # Investigate a better way of managing these dependencies 
 # FIXME: https://github.com/zama-ai/concrete-ml-internal/issues/2685
 python -m pip install --upgrade pip
-python -m pip install pytest==7.1.1 pandas==1.5.3 tensorflow==2.12.0 tf2onnx==1.13.0 torchvision==0.14.1
+python -m pip install pytest==7.4.1 pandas==1.5.3 tensorflow==2.12.0 tf2onnx==1.15.0 torchvision==0.14.1
 
 # Install additional pytest plugins
-python -m pip install pytest-xdist==2.5.0
-python -m pip install pytest-randomly==3.12.0
+python -m pip install pytest-xdist==3.3.1
+python -m pip install pytest-randomly==3.15.0
 python -m pip install pytest-repeat==0.9.1
 
 if ${USE_PIP_WHEEL}; then
@@ -90,7 +90,7 @@ elif ${NO_FLAKY}; then
 
 # Else, intall the pytest coverage plugin and run 'pytest' 
 else
-    python -m pip install pytest-cov==3.0.0
+    python -m pip install pytest-cov==4.1.0
     make pytest
 fi
 


### PR DESCRIPTION
We currently have some coverage issues with pypi tests in the weekly CI (https://github.com/zama-ai/concrete-ml/actions/runs/6450198846/job/17509408289). Not sure why it happens but let's start with updating the packages used 

Besides, we should probably take another look at https://github.com/zama-ai/concrete-ml-internal/issues/2005 and more specifically https://github.com/zama-ai/concrete-ml-internal/issues/2685 in order to avoid such manual updates

refs https://github.com/zama-ai/concrete-ml-internal/issues/4030
