### PR TITLE
chore: add Docker Hub link in release changelogs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -548,6 +548,7 @@ jobs:
           cp ./script/actions_utils/RELEASE_TEMPLATE.md "${RELEASE_BODY_FILE}"
           {
             echo "Docker Image: ${PUBLIC_RELEASE_IMAGE_BASE}:${{ env.GIT_TAG }}";
+            echo "Docker Hub: https://hub.docker.com/r/zamafhe/concrete-ml/tags";
             echo "pip: https://pypi.org/project/concrete-ml/${{ env.PROJECT_VERSION }}";
             echo "Documentation: https://docs.zama.ai/concrete-ml";
             echo "";


### PR DESCRIPTION
I think putting the tag list (https://hub.docker.com/r/zamafhe/concrete-ml/tags) instead of the direct image associated to the tag (https://hub.docker.com/layers/zamafhe/concrete-ml/v1.2.0/images/sha256-94fcd06c55d9f170aab594ba171e6d76ad90a6da110696528a3fb399d50e3a00) is better because less verbose and easier to add (otherwise we need to retrieve the docker image's sha256)

closes https://github.com/zama-ai/concrete-ml-internal/issues/4045