### PR TITLE
chore: revert cleaning of FAILED_TESTS_ARE_FLAKY in CI

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -92,6 +92,9 @@ env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  # The 'FAILED_TESTS_ARE_FLAKY' variable is used to print a warning messages if flaky tests are
+  # re-run. By default, we do not want to print this warning
+  FAILED_TESTS_ARE_FLAKY: "false"
 
 jobs:
   matrix-preparation:
@@ -704,8 +707,6 @@ jobs:
         run: |
           make pytest_and_report
 
-          FAILED_TESTS_ARE_FLAKY="false"
-
           # If regular tests failed, check for flaky tests
           if [ $? -ne 0 ]; then
 
@@ -718,6 +719,8 @@ jobs:
             # Check if all failed tests are known flaky tests
             FAILED_TESTS_ARE_FLAKY=$(jq .all_failed_tests_are_flaky "failed_tests_report.json")
 
+            echo "FAILED_TESTS_ARE_FLAKY=${FAILED_TESTS_ARE_FLAKY}" >> "$GITHUB_ENV"
+
             # If all failed tests are known flaky tests, try to re-run them
             if [[ "${FAILED_TESTS_ARE_FLAKY}" == "true" ]]; then
               make pytest_run_last_failed
@@ -727,8 +730,6 @@ jobs:
               exit 1
             fi
           fi
-
-          echo "FAILED_TESTS_ARE_FLAKY=${FAILED_TESTS_ARE_FLAKY}" >> "$GITHUB_ENV"
 
       # If regular tests passed but at least one known flaky test have been re-run, a warning
       # comment is published in the PR and all flaky tests that initially failed are listed


### PR DESCRIPTION
without this (which is reverting a small commit from last week), the CI remains green even if some tests or coverage fails (as we can see in https://github.com/zama-ai/concrete-ml/actions/runs/6496948965/job/17645139299?pr=333) 🙂  So better keep it that way