### PR TITLE
chore: fix shape

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -319,10 +319,16 @@ def check_array_equal():
 def check_float_array_equal():
     """Fixture to check if two float arrays are equal with epsilon precision tolerance."""
 
-    def check_float_array_equal_impl(a, b, rtol=0, atol=0.001):
-        assert array_allclose_and_same_shape(
-            a, b, rtol, atol
-        ), f"Not equal to tolerance rtol={rtol}, atol={atol}\na: {a}\nb: {b}"
+    def check_float_array_equal_impl(
+        a, b, rtol=0, atol=0.001, error_information: Optional[str] = ""
+    ):
+
+        error_message = (
+            f"Not equal to tolerance rtol={rtol}, atol={atol}\na: {a}\nb: {b}\n"
+            f"{error_information}"
+        )
+
+        assert array_allclose_and_same_shape(a, b, rtol, atol), error_message
 
     return check_float_array_equal_impl
 

--- a/conftest.py
+++ b/conftest.py
@@ -16,6 +16,7 @@ from sklearn.datasets import make_classification, make_regression
 from concrete.ml.common.utils import (
     SUPPORTED_FLOAT_TYPES,
     all_values_are_floats,
+    array_allclose_and_same_shape,
     is_brevitas_model,
     is_classifier_or_partial_classifier,
     is_model_class_in_a_list,
@@ -318,8 +319,10 @@ def check_array_equal():
 def check_float_array_equal():
     """Fixture to check if two float arrays are equal with epsilon precision tolerance."""
 
-    def check_float_array_equal_impl(a, b):
-        assert numpy.all(numpy.isclose(a, b, rtol=0, atol=0.001))
+    def check_float_array_equal_impl(a, b, rtol=0, atol=0.001):
+        assert array_allclose_and_same_shape(
+            a, b, rtol, atol
+        ), f"Not equal to tolerance rtol={rtol}, atol={atol}\na: {a}\nb: {b}"
 
     return check_float_array_equal_impl
 
@@ -338,8 +341,7 @@ def check_r2_score():
         r2_num = numpy.sum(deltas_actual**2)
 
         # If the values are really close, we consider the test passes
-        is_close = numpy.allclose(expected, actual, atol=1e-4, rtol=0)
-        if is_close:
+        if array_allclose_and_same_shape(expected, actual, atol=1e-4, rtol=0):
             return
 
         # If the variance of the target values is very low, fix the max allowed for residuals
@@ -509,10 +511,7 @@ def check_is_good_execution_for_cml_vs_circuit():
                         "a QuantizedModule object."
                     )
 
-            # FIXME: https://github.com/zama-ai/concrete-ml-internal/issues/2806
-            # fp64 comparisons do not pass the numpy.array_equal while the quantized
-            # int64 values do.
-            if numpy.isclose(results_cnp_circuit, results_model).all():
+            if array_allclose_and_same_shape(results_cnp_circuit, results_model):
                 return
 
         raise RuntimeError(

--- a/src/concrete/ml/common/utils.py
+++ b/src/concrete/ml/common/utils.py
@@ -583,3 +583,27 @@ def all_values_are_of_dtype(*values: Any, dtypes: Union[str, List[str]]) -> bool
         supported_dtypes[dtype] = supported_dtype
 
     return all(_is_of_dtype(value, supported_dtypes) for value in values)
+
+
+def array_allclose_and_same_shape(
+    a, b, rtol: float = 1e-05, atol: float = 1e-08, equal_nan: bool = False
+) -> bool:
+    """Check if two numpy arrays are equal within a tolerances and have the same shape.
+
+    Args:
+        a (numpy.ndarray): The first input array
+        b (numpy.ndarray): The second input array
+        rtol (float): The relative tolerance parameter
+        atol (float): The absolute tolerance parameter
+        equal_nan (bool): Whether to compare NaN’s as equal. If True, NaN’s in a will be considered
+            equal to NaN’s in b in the output array
+
+    Returns:
+        bool: True if the arrays have the same shape and all elements are equal within the specified
+            tolerances, False otherwise.
+    """
+
+    a = check_array_and_assert(a, ensure_2d=False)
+    b = check_array_and_assert(b, ensure_2d=False)
+
+    return a.shape == b.shape and numpy.allclose(a, b, rtol, atol, equal_nan)

--- a/src/concrete/ml/common/utils.py
+++ b/src/concrete/ml/common/utils.py
@@ -603,7 +603,7 @@ def array_allclose_and_same_shape(
             tolerances, False otherwise.
     """
 
-    a = check_array_and_assert(a, ensure_2d=False)
-    b = check_array_and_assert(b, ensure_2d=False)
+    assert isinstance(a, numpy.ndarray)
+    assert isinstance(b, numpy.ndarray)
 
     return a.shape == b.shape and numpy.allclose(a, b, rtol, atol, equal_nan)

--- a/src/concrete/ml/quantization/quantized_module_passes.py
+++ b/src/concrete/ml/quantization/quantized_module_passes.py
@@ -242,7 +242,7 @@ class PowerOfTwoScalingRoundPBSAdapter:
             log2_value = int(numpy.rint(numpy.log2(value)))
             # Check that the integer power of two is close to the original value
             # with a small percentage tolerance
-            if numpy.isclose(numpy.power(2.0, log2_value), value, rtol=0.01):
+            if numpy.allclose(numpy.power(2.0, log2_value), value, rtol=0.01):
                 return log2_value, True
             return 0, False
 

--- a/src/concrete/ml/quantization/quantizers.py
+++ b/src/concrete/ml/quantization/quantizers.py
@@ -747,7 +747,7 @@ class UniformQuantizer(UniformQuantizationParameters, QuantizationOptions, MinMa
         assert self.scale is not None
 
         if QUANT_ROUND_LIKE_ROUND_PBS:
-            qvalues = numpy.floor(values / self.scale + self.zero_point + 0.5)
+            qvalues = numpy.floor(values / self.scale + self.zero_point + 0.5)  # pragma: no cover
         else:
             qvalues = numpy.rint(values / self.scale + self.zero_point)
 

--- a/src/concrete/ml/quantization/quantizers.py
+++ b/src/concrete/ml/quantization/quantizers.py
@@ -7,9 +7,9 @@ from typing import Any, Dict, Optional, TextIO, Union, get_type_hints
 
 import numpy
 
-from ..common import utils
 from ..common.debugging import assert_true
 from ..common.serialization.dumpers import dump, dumps
+from ..common.utils import QUANT_ROUND_LIKE_ROUND_PBS, array_allclose_and_same_shape
 
 STABILITY_CONST = 10**-6
 
@@ -369,7 +369,7 @@ class MinMaxQuantizationStats:
 
         re_quant_scales = numpy.rint(unique_scales / min_scale) * min_scale
 
-        return numpy.allclose(unique_scales, re_quant_scales, atol=0.02)
+        return array_allclose_and_same_shape(unique_scales, re_quant_scales, atol=0.02)
 
 
 class UniformQuantizationParameters:
@@ -746,7 +746,7 @@ class UniformQuantizer(UniformQuantizationParameters, QuantizationOptions, MinMa
         assert self.offset is not None
         assert self.scale is not None
 
-        if utils.QUANT_ROUND_LIKE_ROUND_PBS:
+        if QUANT_ROUND_LIKE_ROUND_PBS:
             qvalues = numpy.floor(values / self.scale + self.zero_point + 0.5)
         else:
             qvalues = numpy.rint(values / self.scale + self.zero_point)

--- a/src/concrete/ml/sklearn/base.py
+++ b/src/concrete/ml/sklearn/base.py
@@ -2086,9 +2086,10 @@ class SklearnKNeighborsMixin(BaseEstimator, sklearn.base.BaseEstimator, ABC):
 
         topk_labels = []
         for query in X:
-            topk_labels.append(BaseEstimator.predict(self, query[None], fhe=fhe))
+            query = numpy.expand_dims(query, 0)
+            topk_labels.append(BaseEstimator.predict(self, query, fhe=fhe)[0])
 
-        return numpy.array(topk_labels).squeeze()
+        return numpy.array(topk_labels)
 
     def predict(self, X: Data, fhe: Union[FheMode, str] = FheMode.DISABLE) -> numpy.ndarray:
 

--- a/tests/onnx/test_onnx_ops_impl.py
+++ b/tests/onnx/test_onnx_ops_impl.py
@@ -52,9 +52,10 @@ def test_numpy_gemm(alpha, beta, trans_a, size_a, trans_b, size_b):
 
     # Can be a bit different if we have floats
     if isinstance(alpha, float) or isinstance(beta, float):
-        assert numpy.isclose(
+
+        assert numpy.allclose(
             got, expected
-        ).all(), f"expected {expected}, got {got}, abs diff is {numpy.abs(got - expected)}"
+        ), f"expected {expected}, got {got}, abs diff is {numpy.abs(got - expected)}"
     else:
         assert numpy.array_equal(
             got, expected

--- a/tests/quantization/test_quantizers.py
+++ b/tests/quantization/test_quantizers.py
@@ -22,7 +22,9 @@ from concrete.ml.quantization.quantizers import (
     [pytest.param(True, True), pytest.param(True, False), pytest.param(False, False)],
 )
 @pytest.mark.parametrize("values", [pytest.param(numpy.random.randn(2000))])
-def test_quant_dequant_update(values, n_bits, is_signed, is_symmetric, check_array_equal):
+def test_quant_dequant_update(
+    values, n_bits, is_signed, is_symmetric, check_array_equal, check_float_array_equal
+):
     """Test the quant and de-quant function."""
 
     quant_array = QuantizedArray(n_bits, values, is_signed=is_signed, is_symmetric=is_symmetric)
@@ -42,7 +44,7 @@ def test_quant_dequant_update(values, n_bits, is_signed, is_symmetric, check_arr
 
     # Check that all values are close
     tolerance = quant_array.quantizer.scale / 2
-    assert numpy.isclose(dequant_values, values, atol=tolerance).all()
+    check_float_array_equal(dequant_values, values, atol=tolerance)
 
     # Explain the choice of tolerance
     # This test checks the values are quantized and de-quantized correctly

--- a/tests/sklearn/test_sklearn_models.py
+++ b/tests/sklearn/test_sklearn_models.py
@@ -1130,13 +1130,12 @@ def check_load_fitted_sklearn_linear_models(model_class, n_bits, x, y, check_flo
     y_pred_simulate = concrete_model.predict(x, fhe="simulate")
     y_pred_simulate_loaded = loaded_concrete_model.predict(x, fhe="simulate")
 
-    try:
-        check_float_array_equal(y_pred_simulate, y_pred_simulate_loaded)
-    except AssertionError as e:
-        raise AssertionError(
-            "Simulated predictions from the initial model do not match the ones "
-            "made from the loaded one."
-        ) from e
+    check_float_array_equal(
+        y_pred_simulate,
+        y_pred_simulate_loaded,
+        error_information="Simulated predictions from the initial model do not match the ones made "
+        "from the loaded one.",
+    )
 
 
 # Neural network models are skipped for this test

--- a/tests/torch/test_compile_torch.py
+++ b/tests/torch/test_compile_torch.py
@@ -1127,7 +1127,12 @@ def test_net_has_no_tlu(
 @pytest.mark.parametrize("is_qat", [True, False])
 @pytest.mark.parametrize("n_channels", [2])
 def test_shape_operations_net(
-    simulate, n_channels, is_qat, default_configuration, check_graph_output_has_no_tlu
+    simulate,
+    n_channels,
+    is_qat,
+    default_configuration,
+    check_graph_output_has_no_tlu,
+    check_float_array_equal,
 ):
     """Test a pattern of reshaping, concatenation, chunk extraction."""
     net = ShapeOperationsNet(is_qat)
@@ -1166,7 +1171,7 @@ def test_shape_operations_net(
         # In PTQ the results do not match because of a-priori set quantization options
         # Currently no solution for concat/reshape/transpose correctness in PTQ is proposed.
         if is_qat:
-            assert numpy.allclose(torch_output, predictions, atol=0.05, rtol=0)
+            check_float_array_equal(torch_output, predictions, atol=0.05, rtol=0)
 
             # In QAT, since the quantization is defined a-priori, all TLUs will be removed
             # and the input quantizer is moved to the clear. We can thus check there are no TLUs


### PR DESCRIPTION
The problem occurred after I merged the changes of this PR (https://github.com/zama-ai/concrete-ml/pull/333) yesterday.
Where I added the `get_topk_labels` method to the `predict` of KNN class.

- The issue comes from the squeeze operation:
If the input shape is (1, 1, k), squeezed turns it to (k,). Which I have corrected it.

- Why the test didn't catch this problem?
`numpy.isclose`, compares elements in arrays but doesn't consider their shape.
Exemple:
```
a = numpy.array([0])
b = numpy.array([0, 0, 0])
numpy.isclose(a, b, rtol=0, atol=0.001)
True
```
In the flaky: https://github.com/zama-ai/concrete-ml-internal/issues/4092:

```
a = numpy.array([0])
b = numpy.array([0, 0, 1])
numpy.isclose(a, b, rtol=0, atol=0.001)
False.
```

In this PR, I corrected the shape mismatch.

I changed `_isclose` by `numpy.testing.assert_allclose`, which takes into account the shape, in our tests.


closes https://github.com/zama-ai/concrete-ml-internal/issues/2806
closes https://github.com/zama-ai/concrete-ml-internal/issues/4092