### PR TITLE
chore: enable refresh_one_notebook action to run in parallel

### DIFF
--- a/.github/workflows/refresh-one-notebook.yaml
+++ b/.github/workflows/refresh-one-notebook.yaml
@@ -43,7 +43,7 @@ on:
         required: true
 
 concurrency:
-  group: "${{ github.ref }}-${{ github.event_name }}-${{ github.workflow }}"
+  group: "${{ github.ref }}-${{ github.event_name }}-${{ github.workflow }}-${{ github.event.inputs.notebook }}"
   cancel-in-progress: false
 
 env:
@@ -174,7 +174,7 @@ jobs:
           source .venv/bin/activate
           cd ./use_case_examples/titanic && ./download_data.sh
           
-      - name: Refresh One Notebook
+      - name: Refresh ${{ github.event.inputs.notebook }}
         run: |
           make jupyter_execute_one NOTEBOOK="${{ env[env.NOTEBOOK_NAME] }}"
       


### PR DESCRIPTION
Without this, refreshing several notebooks one after the other targeting a same branch forces the workflows to run one after the other