### PR TITLE
feat: support Expand Equal ONNX op

### DIFF
--- a/docs/deep-learning/onnx_support.md
+++ b/docs/deep-learning/onnx_support.md
@@ -136,6 +136,7 @@ The following operators are supported for evaluation and conversion to an equiva
 - Equal
 - Erf
 - Exp
+- Expand
 - Flatten
 - Floor
 - Gather

--- a/src/concrete/ml/onnx/onnx_utils.py
+++ b/src/concrete/ml/onnx/onnx_utils.py
@@ -243,8 +243,10 @@ from .ops_impl import (
     numpy_div,
     numpy_elu,
     numpy_equal,
+    numpy_equal_float,
     numpy_erf,
     numpy_exp,
+    numpy_expand,
     numpy_flatten,
     numpy_floor,
     numpy_gather,
@@ -350,7 +352,6 @@ ONNX_OPS_TO_NUMPY_IMPL: Dict[str, Callable[..., Tuple[numpy.ndarray, ...]]] = {
     "Sub": numpy_sub,
     "Log": numpy_log,
     "Exp": numpy_exp,
-    "Equal": numpy_equal,
     "Identity": numpy_identity,
     "Reshape": numpy_reshape,
     "Transpose": numpy_transpose,
@@ -380,6 +381,7 @@ ONNX_OPS_TO_NUMPY_IMPL: Dict[str, Callable[..., Tuple[numpy.ndarray, ...]]] = {
     "Gather": numpy_gather,
     "Shape": numpy_shape,
     "ConstantOfShape": numpy_constant_of_shape,
+    "Expand": numpy_expand,
 }
 
 
@@ -396,6 +398,7 @@ ONNX_COMPARISON_OPS_TO_NUMPY_IMPL_FLOAT: Dict[str, Callable[..., Tuple[numpy.nda
     "GreaterOrEqual": numpy_greater_or_equal_float,
     "Less": numpy_less_float,
     "LessOrEqual": numpy_less_or_equal_float,
+    "Equal": numpy_equal_float,
 }
 
 # Comparison operators used in tree-based models as they keep the outputs' boolean dtype.
@@ -406,6 +409,7 @@ ONNX_COMPARISON_OPS_TO_NUMPY_IMPL_BOOL: Dict[str, Callable[..., Tuple[numpy.ndar
     "GreaterOrEqual": numpy_greater_or_equal,
     "Less": numpy_less,
     "LessOrEqual": numpy_less_or_equal,
+    "Equal": numpy_equal,
 }
 # All numpy operators used for tree-based models that support auto rounding
 ONNX_COMPARISON_OPS_TO_ROUNDED_TREES_NUMPY_IMPL_BOOL = {

--- a/src/concrete/ml/onnx/ops_impl.py
+++ b/src/concrete/ml/onnx/ops_impl.py
@@ -2065,21 +2065,21 @@ def numpy_gather(
 
 
 @onnx_func_raw_args("shape")
-def numpy_expand(x: numpy.ndarray, shape=None) -> Tuple[numpy.ndarray]:
+def numpy_expand(x: numpy.ndarray, shape: Optional[Tuple[int]] = None) -> Tuple[numpy.ndarray]:
     """Apply the expand operator in numpy according to ONNX spec.
 
     See https://github.com/onnx/onnx/blob/main/docs/Operators.md#expand
 
     Args:
         x (numpy.ndarray): Input tensor.
-        shape: Tuple of the new shape.
+        shape (Optional[Tuple[int]]): Tuple of the new shape.
 
     Returns:
         Tuple[numpy.ndarray]: Output tensor.
     """
     target_shape = numpy.array(shape, dtype=int)
-    padding = len(target_shape) - len(x.shape)
+    shape_difference = len(target_shape) - len(x.shape)
 
-    assert_true(padding >= 0, "Target shape cannot have fewer dimensions than input shape")
+    assert_true(shape_difference >= 0, "Target shape cannot have fewer dimensions than input shape")
 
     return (numpy.broadcast_to(x, target_shape),)

--- a/src/concrete/ml/onnx/ops_impl.py
+++ b/src/concrete/ml/onnx/ops_impl.py
@@ -941,6 +941,25 @@ def rounded_numpy_equal_for_trees(
     return (numpy.equal(x, y),)
 
 
+def numpy_equal_float(
+    x: numpy.ndarray,
+    y: numpy.ndarray,
+) -> Tuple[numpy.ndarray]:
+    """Compute equal in numpy according to ONNX spec and cast outputs to floats.
+
+    See https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Equal-13
+
+    Args:
+        x (numpy.ndarray): Input tensor
+        y (numpy.ndarray): Input tensor
+
+    Returns:
+        Tuple[numpy.ndarray]: Output tensor
+    """
+
+    return cast_to_float(numpy_equal(x, y))
+
+
 def numpy_not(
     x: numpy.ndarray,
 ) -> Tuple[numpy.ndarray]:
@@ -2043,3 +2062,24 @@ def numpy_gather(
     slices = tuple(slice(None) if i != axis else indices_list for i in range(x.ndim))
 
     return (x[slices],)
+
+
+@onnx_func_raw_args("shape")
+def numpy_expand(x: numpy.ndarray, shape=None) -> Tuple[numpy.ndarray]:
+    """Apply the expand operator in numpy according to ONNX spec.
+
+    See https://github.com/onnx/onnx/blob/main/docs/Operators.md#expand
+
+    Args:
+        x (numpy.ndarray): Input tensor.
+        shape: Tuple of the new shape.
+
+    Returns:
+        Tuple[numpy.ndarray]: Output tensor.
+    """
+    target_shape = numpy.array(shape, dtype=int)
+    padding = len(target_shape) - len(x.shape)
+
+    assert_true(padding >= 0, "Target shape cannot have fewer dimensions than input shape")
+
+    return (numpy.broadcast_to(x, target_shape),)

--- a/src/concrete/ml/pytest/torch_models.py
+++ b/src/concrete/ml/pytest/torch_models.py
@@ -1165,6 +1165,7 @@ class ShapeOperationsNet(nn.Module):
     def __init__(self, is_qat):
         super().__init__()
         self.is_qat = is_qat
+        self.is_qat_compatible = True
         if is_qat:
             self.input_quant = qnn.QuantIdentity(bit_width=8)
 
@@ -1532,3 +1533,24 @@ class AddNet(nn.Module):
             Result of adding x and y.
         """
         return x + y
+
+
+class ExpandModel(nn.Module):
+    """Minimalist network that expands the input tensor to a larger size."""
+
+    def __init__(self, is_qat):  # pylint: disable=unused-argument
+        super().__init__()
+        self.is_qat_compatible = False
+
+    @staticmethod
+    def forward(x):
+        """Expand the input tensor to the target size.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Expanded tensor.
+        """
+        x = x.reshape(x.shape + (1,))
+        return x.expand(x.shape[:-1] + (4,))

--- a/src/concrete/ml/pytest/torch_models.py
+++ b/src/concrete/ml/pytest/torch_models.py
@@ -1165,7 +1165,6 @@ class ShapeOperationsNet(nn.Module):
     def __init__(self, is_qat):
         super().__init__()
         self.is_qat = is_qat
-        self.is_qat_compatible = True
         if is_qat:
             self.input_quant = qnn.QuantIdentity(bit_width=8)
 
@@ -1540,10 +1539,11 @@ class ExpandModel(nn.Module):
 
     def __init__(self, is_qat):  # pylint: disable=unused-argument
         super().__init__()
-        self.is_qat_compatible = False
+        self.is_qat = is_qat
+        if is_qat:
+            self.input_quant = qnn.QuantIdentity(bit_width=8)
 
-    @staticmethod
-    def forward(x):
+    def forward(self, x):
         """Expand the input tensor to the target size.
 
         Args:
@@ -1552,5 +1552,7 @@ class ExpandModel(nn.Module):
         Returns:
             torch.Tensor: Expanded tensor.
         """
+        if self.is_qat:
+            x = self.input_quant(x)
         x = x.reshape(x.shape + (1,))
         return x.expand(x.shape[:-1] + (4,))

--- a/tests/quantization/test_quantized_ops.py
+++ b/tests/quantization/test_quantized_ops.py
@@ -1252,7 +1252,6 @@ def test_quantized_prelu(n_bits, input_range, input_shape, slope, is_signed, che
 @pytest.fixture(scope="module")
 def random_test_data():
     """Generate data for comparisons operators."""
-    numpy.random.seed(42)  # Fixing the seed for reproducibility
     return [
         (
             numpy.random.uniform(size=(1, 3, 32, 32)) * 4,

--- a/tests/torch/test_compile_torch.py
+++ b/tests/torch/test_compile_torch.py
@@ -1150,8 +1150,6 @@ def test_shape_operations_net(
 ):
     """Test a pattern of reshaping, concatenation, chunk extraction."""
     model = model_class(is_qat)
-    if is_qat and not model.is_qat_compatible:
-        pytest.skip(f"Model {model_class.__name__} is not compatible with is_qat=True")
 
     # Shape transformation do not support >1 example in the inputset
     # FIXME: https://github.com/zama-ai/concrete-ml-internal/issues/3871


### PR DESCRIPTION
ref https://github.com/zama-ai/concrete-ml-internal/issues/4158

I had to implement Equal as well because the `torch.norm(...)` seems to create an Equal node. It's only there to compute constants so it does not appear in the final FHE graph.