### PR TITLE
chore: change the way we use gitleaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -715,9 +715,11 @@ check_supported_ops:
 	git diff docs/deep-learning/onnx_support.md
 	git diff --quiet docs/deep-learning/onnx_support.md
 
+# The log-opts option checks the whole history between the first commit and the current commit
+# The default of gitleaks it to check the whole history.
 .PHONY: gitleaks # Check for secrets in the repo using gitleaks
 gitleaks:
-	gitleaks --source "$${PWD}" detect --redact -v
+	gitleaks --source "$${PWD}" detect --redact -v --log-opts="$$(git rev-list HEAD | tail -n 1)..$$(git rev-parse HEAD)"
 
 .PHONY: sanity_check # Sanity checks, e.g. to check that a release is viable
 sanity_check:


### PR DESCRIPTION
Until now we used gitleaks to check the whole history but it makes more sense to only check from the first commit to the current commit.

Otherwise it would break all PRs if someone pushed something that was detected as a leak.
This introduces some issues also when working with multiple remotes.

The commit changes the behavior to check from first commit to current commit.