### PR TITLE
chore: remove last mentions of Concrete-Numpy

### DIFF
--- a/.github/workflows/single_benchmark.yaml
+++ b/.github/workflows/single_benchmark.yaml
@@ -155,7 +155,7 @@ jobs:
             # Needed for some reason
             make setup_env
             source ./.venv/bin/activate
-            python -m pip show concrete-numpy
+            python -m pip show concrete-python
 
       # Now we get our most up to date version
       - name: Run the benchmark command

--- a/conftest.py
+++ b/conftest.py
@@ -479,8 +479,8 @@ def check_is_good_execution_for_cml_vs_circuit():
         for _ in range(n_allowed_runs):
             # Check if model is QuantizedModule
             if isinstance(model, QuantizedModule):
-                results_cnp_circuit = model.forward(*inputs, fhe=fhe_mode)
-                results_model = model.forward(*inputs, fhe="disable")
+                y_pred_fhe = model.forward(*inputs, fhe=fhe_mode)
+                y_pred_quantized = model.forward(*inputs, fhe="disable")
 
             else:
                 assert isinstance(
@@ -504,12 +504,12 @@ def check_is_good_execution_for_cml_vs_circuit():
                     if is_classifier_or_partial_classifier(model) and not isinstance(
                         model, SklearnKNeighborsMixin
                     ):
-                        results_cnp_circuit = model.predict_proba(*inputs, fhe=fhe_mode)
-                        results_model = model.predict_proba(*inputs, fhe="disable")
+                        y_pred_fhe = model.predict_proba(*inputs, fhe=fhe_mode)
+                        y_pred_quantized = model.predict_proba(*inputs, fhe="disable")
 
                     else:
-                        results_cnp_circuit = model.predict(*inputs, fhe=fhe_mode)
-                        results_model = model.predict(*inputs, fhe="disable")
+                        y_pred_fhe = model.predict(*inputs, fhe=fhe_mode)
+                        y_pred_quantized = model.predict(*inputs, fhe="disable")
 
                 else:
                     raise ValueError(
@@ -517,12 +517,12 @@ def check_is_good_execution_for_cml_vs_circuit():
                         "a QuantizedModule object."
                     )
 
-            if array_allclose_and_same_shape(results_cnp_circuit, results_model):
+            if array_allclose_and_same_shape(y_pred_fhe, y_pred_quantized):
                 return
 
         raise RuntimeError(
-            f"Mismatch between circuit results:\n{results_cnp_circuit}\n"
-            f"and model function results:\n{results_model}"
+            f"Mismatch between circuit results:\n{y_pred_fhe}\n"
+            f"and model function results:\n{y_pred_quantized}"
         )
 
     return check_is_good_execution_for_cml_vs_circuit_impl

--- a/script/doc_utils/check_forbidden_words.py
+++ b/script/doc_utils/check_forbidden_words.py
@@ -124,6 +124,7 @@ def process_file(file_str: str, do_open_problematic_files=False):
         ("concrete Numpy", [], []),  # use Concrete
         ("Concrete numpy", [], []),  # use Concrete
         ("Concrete Numpy", [], []),  # use Concrete
+        ("cnp", [], []),  # use fhe (or cp, worst case)
         ("tool-kit", [], []),  # use toolkit
         ("tool-kits", [], []),  # use toolkits
         (

--- a/script/make_utils/check_installation_with_all_python.sh
+++ b/script/make_utils/check_installation_with_all_python.sh
@@ -73,8 +73,7 @@ do
         # Build the wheel file
         poetry build -f wheel
 
-        # Install the dependencies as PyPI would do using the wheel file, inclusing the current
-        # Concrete-Numpy RC version
+        # Install the dependencies as PyPI would do using the wheel file
         PYPI_WHEEL=$(find dist -type f -name "*.whl")
         python -m pip install "${PYPI_WHEEL}"
 

--- a/script/make_utils/pytest_pypi_cml.sh
+++ b/script/make_utils/pytest_pypi_cml.sh
@@ -65,8 +65,8 @@ if ${USE_PIP_WHEEL}; then
     # Build the wheel file
     poetry build -f wheel
 
-    # Install the dependencies as PyPI would do using the wheel file, inclusing the current
-    # Concrete-Numpy RC version
+    # Install the dependencies as PyPI would do using the wheel file as well as the given
+    # Concrete-Python version
     PYPI_WHEEL=$(find dist -type f -name "*.whl")
     python -m pip install "${PYPI_WHEEL}"
     python -m pip install "${CONCRETE_PYTHON}"

--- a/src/concrete/ml/onnx/onnx_impl_utils.py
+++ b/src/concrete/ml/onnx/onnx_impl_utils.py
@@ -3,8 +3,8 @@
 from typing import Callable, Tuple, Union
 
 import numpy
-from concrete.fhe import conv as cnp_conv
-from concrete.fhe import ones as cnp_ones
+from concrete.fhe import conv as fhe_conv
+from concrete.fhe import ones as fhe_ones
 from concrete.fhe import round_bit_pattern
 from concrete.fhe.tracing import Tracer
 
@@ -52,7 +52,7 @@ def numpy_onnx_pad(
         # to the real-axis 0
         if int_only:
             # Work in integer Concrete mode
-            x_pad = cnp_ones(tuple(padded_shape)) * numpy.int64(pad_value)
+            x_pad = fhe_ones(tuple(padded_shape)) * numpy.int64(pad_value)
         else:
             # Floating point mode
             x_pad = numpy.ones(padded_shape, dtype=numpy.float32) * pad_value
@@ -219,7 +219,7 @@ def onnx_avgpool_compute_norm_const(
         padded_ceil[:, :, 0 : padded_flr.shape[2], 0 : padded_flr.shape[3]] = 1
 
         # Compute the sum of valid indices in each kernel position
-        norm_const = cnp_conv(
+        norm_const = fhe_conv(
             padded_ceil, kernel, None, [0, 0, 0, 0], strides, None, None, n_in_channels
         )
     else:

--- a/src/concrete/ml/onnx/ops_impl.py
+++ b/src/concrete/ml/onnx/ops_impl.py
@@ -8,8 +8,8 @@ import numpy
 import onnx
 import onnx.helper
 from brevitas.function import max_int, min_int
-from concrete.fhe import conv as cnp_conv
-from concrete.fhe import maxpool as cnp_maxpool
+from concrete.fhe import conv as fhe_conv
+from concrete.fhe import maxpool as fhe_maxpool
 from concrete.fhe import univariate
 from scipy import special
 from typing_extensions import SupportsIndex
@@ -1317,7 +1317,7 @@ def numpy_conv(
     x_pad = numpy_onnx_pad(x, pads)
 
     # Compute the torch convolution
-    res = cnp_conv(x_pad, w, b, None, strides, dilations, None, group)
+    res = fhe_conv(x_pad, w, b, None, strides, dilations, None, group)
 
     return (res,)
 
@@ -1381,7 +1381,7 @@ def numpy_avgpool(
     q_input_pad = numpy_onnx_pad(x, pool_pads)
 
     # Compute the sums of input values for each kernel position
-    res = cnp_conv(q_input_pad, kernel, None, [0, 0, 0, 0], strides, None, None, n_in_channels)
+    res = fhe_conv(q_input_pad, kernel, None, [0, 0, 0, 0], strides, None, None, n_in_channels)
 
     # Compute the average of the input values for each kernel position
     res /= norm_const
@@ -1445,7 +1445,7 @@ def numpy_maxpool(
     q_input_pad = numpy_onnx_pad(x, pool_pads)
 
     fake_pads = [0] * len(pads)
-    res = cnp_maxpool(
+    res = fhe_maxpool(
         q_input_pad,
         kernel_shape=kernel_shape,
         strides=strides,

--- a/src/concrete/ml/quantization/quantized_module.py
+++ b/src/concrete/ml/quantization/quantized_module.py
@@ -495,7 +495,7 @@ class QuantizedModule:
             "The quantized module is not compiled. Please run compile(...) first before "
             "executing it in FHE.",
         )
-        results_cnp_circuit_list: List[List[numpy.ndarray]] = [[] for _ in self.output_quantizers]
+        q_result_by_output: List[List[numpy.ndarray]] = [[] for _ in self.output_quantizers]
         for i in range(q_x[0].shape[0]):
 
             # Extract example i from every element in the tuple q_x
@@ -524,19 +524,19 @@ class QuantizedModule:
             # Execute the forward pass in FHE or with simulation
             q_result = to_tuple(predict_method(*q_input))
 
-            assert len(q_result) == len(results_cnp_circuit_list), (
+            assert len(q_result) == len(q_result_by_output), (
                 "Number of outputs does not match the number of output quantizers.\n"
                 f"{len(q_result)=}!={len(self.output_quantizers)=}"
             )
             for elt_index, elt in enumerate(q_result):
-                results_cnp_circuit_list[elt_index].append(elt)
+                q_result_by_output[elt_index].append(elt)
 
-        results_cnp_circuit: Tuple[numpy.ndarray, ...] = tuple(
-            numpy.concatenate(elt, axis=0) for elt in results_cnp_circuit_list
+        q_results: Tuple[numpy.ndarray, ...] = tuple(
+            numpy.concatenate(elt, axis=0) for elt in q_result_by_output
         )
-        if len(results_cnp_circuit) == 1:
-            return results_cnp_circuit[0]
-        return results_cnp_circuit
+        if len(q_results) == 1:
+            return q_results[0]
+        return q_results
 
     def quantize_input(self, *x: numpy.ndarray) -> Union[numpy.ndarray, Tuple[numpy.ndarray, ...]]:
         """Take the inputs in fp32 and quantize it using the learned quantization parameters.


### PR DESCRIPTION
There is still a method called "cpn_round" in our mixin quantized op but that would create a breaking change, so I added it in https://github.com/zama-ai/concrete-ml-internal/issues/3995 

Also, there are a few (3 I think) links to some concrete-numpy-internal issues left

closes https://github.com/zama-ai/concrete-ml-internal/issues/4074
closes https://github.com/zama-ai/concrete-ml-internal/issues/2250