### PR TITLE
chore: remove old optimization in numpy_gemm

### DIFF
--- a/src/concrete/ml/onnx/ops_impl.py
+++ b/src/concrete/ml/onnx/ops_impl.py
@@ -288,23 +288,7 @@ def numpy_gemm(
     b_prime = numpy.transpose(b) if transB else b
     c_prime: Union[numpy.ndarray, float] = c if c is not None else 0
 
-    # Do
-    #
-    #       y = processed_alpha * numpy.matmul(a_prime, b_prime) + processed_beta * c_prime
-    #
-    # in an efficient way, i.e., to make tracing directly optimized, without expecting any opt from
-    # the compiler here
-
-    y = numpy.matmul(a_prime, b_prime)
-
-    if processed_alpha != 1:
-        y = y * processed_alpha
-
-    if numpy.any(c_prime != 0):
-        if processed_beta == 1:
-            y = y + c_prime
-        else:
-            y = y + processed_beta * c_prime
+    y = processed_alpha * numpy.matmul(a_prime, b_prime) + processed_beta * c_prime
 
     return (y,)
 


### PR DESCRIPTION
I believe these optimizations are old, now the compiler should handle them (based on this comment for ex : https://github.com/zama-ai/concrete-compiler-internal/issues/788#issuecomment-1326138981)

do you confirm @bcm-at-zama ? cc @andrei-stoian-zama 

EDIT: actually there was an issue for it in CML (https://github.com/zama-ai/concrete-ml-internal/issues/154) but the one associated to it in old CN (https://github.com/zama-ai/concrete-numpy-internal/issues/1400) has been closes without confirmation that such an optim is done on the compiler side ... maybe @rudy-6-4 @umut-sahin or @BourgerieQuentin can confirm ?