### PR TITLE
docs: document n_bits for compile torch functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Various tutorials are given for [built-in models](docs/built-in-models/ml_exampl
 
 If you have built awesome projects using Concrete ML, feel free to let us know and we'll link to them!
 
-## Contributing 
+## Contributing
 
 To contribute to Concrete ML, please refer to this [section of the documentation](docs/developer-guide/contributing.md).
 

--- a/src/concrete/ml/torch/compile.py
+++ b/src/concrete/ml/torch/compile.py
@@ -158,7 +158,12 @@ def _compile_torch_or_onnx_model(
         artifacts (DebugArtifacts): Artifacts object to fill during compilation
         show_mlir (bool): if set, the MLIR produced by the converter and which is going
             to be sent to the compiler backend is shown on the screen, e.g., for debugging or demo
-        n_bits: the number of bits for the quantization
+        n_bits: number of bits for quantization, can be a single value or
+            a dictionary with the following keys :
+            - "op_inputs" and "op_weights" (mandatory)
+            - "model_inputs" and "model_outputs" (optional, default to 5 bits).
+            When using a single integer for n_bits, its value is assigned to "op_inputs" and
+            "op_weights" bits.
         rounding_threshold_bits (int): if not None, every accumulators in the model are rounded down
             to the given bits of precision
         p_error (Optional[float]): probability of error of a single PBS
@@ -253,7 +258,12 @@ def compile_torch_model(
             during compilation
         show_mlir (bool): if set, the MLIR produced by the converter and which is going
             to be sent to the compiler backend is shown on the screen, e.g., for debugging or demo
-        n_bits: the number of bits for the quantization
+        n_bits: number of bits for quantization, can be a single value or
+            a dictionary with the following keys :
+            - "op_inputs" and "op_weights" (mandatory)
+            - "model_inputs" and "model_outputs" (optional, default to 5 bits).
+            When using a single integer for n_bits, its value is assigned to "op_inputs" and
+            "op_weights" bits.
         rounding_threshold_bits (int): if not None, every accumulators in the model are rounded down
             to the given bits of precision
         p_error (Optional[float]): probability of error of a single PBS
@@ -330,7 +340,12 @@ def compile_onnx_model(
             during compilation
         show_mlir (bool): if set, the MLIR produced by the converter and which is going
             to be sent to the compiler backend is shown on the screen, e.g., for debugging or demo
-        n_bits: the number of bits for the quantization
+        n_bits: number of bits for quantization, can be a single value or
+            a dictionary with the following keys :
+            - "op_inputs" and "op_weights" (mandatory)
+            - "model_inputs" and "model_outputs" (optional, default to 5 bits).
+            When using a single integer for n_bits, its value is assigned to "op_inputs" and
+            "op_weights" bits.
         rounding_threshold_bits (int): if not None, every accumulators in the model are rounded down
             to the given bits of precision
         p_error (Optional[float]): probability of error of a single PBS

--- a/src/concrete/ml/torch/compile.py
+++ b/src/concrete/ml/torch/compile.py
@@ -158,12 +158,12 @@ def _compile_torch_or_onnx_model(
         artifacts (DebugArtifacts): Artifacts object to fill during compilation
         show_mlir (bool): if set, the MLIR produced by the converter and which is going
             to be sent to the compiler backend is shown on the screen, e.g., for debugging or demo
-        n_bits: number of bits for quantization, can be a single value or
-            a dictionary with the following keys :
+        n_bits (Union[int, Dict[str, int]]): number of bits for quantization, can be a single value
+            or a dictionary with the following keys :
             - "op_inputs" and "op_weights" (mandatory)
             - "model_inputs" and "model_outputs" (optional, default to 5 bits).
             When using a single integer for n_bits, its value is assigned to "op_inputs" and
-            "op_weights" bits.
+            "op_weights" bits. Default is 8 bits.
         rounding_threshold_bits (int): if not None, every accumulators in the model are rounded down
             to the given bits of precision
         p_error (Optional[float]): probability of error of a single PBS
@@ -258,12 +258,12 @@ def compile_torch_model(
             during compilation
         show_mlir (bool): if set, the MLIR produced by the converter and which is going
             to be sent to the compiler backend is shown on the screen, e.g., for debugging or demo
-        n_bits: number of bits for quantization, can be a single value or
-            a dictionary with the following keys :
+        n_bits (Union[int, Dict[str, int]]): number of bits for quantization, can be a single value
+            or a dictionary with the following keys :
             - "op_inputs" and "op_weights" (mandatory)
             - "model_inputs" and "model_outputs" (optional, default to 5 bits).
             When using a single integer for n_bits, its value is assigned to "op_inputs" and
-            "op_weights" bits.
+            "op_weights" bits. Default is 8 bits.
         rounding_threshold_bits (int): if not None, every accumulators in the model are rounded down
             to the given bits of precision
         p_error (Optional[float]): probability of error of a single PBS
@@ -340,12 +340,12 @@ def compile_onnx_model(
             during compilation
         show_mlir (bool): if set, the MLIR produced by the converter and which is going
             to be sent to the compiler backend is shown on the screen, e.g., for debugging or demo
-        n_bits: number of bits for quantization, can be a single value or
-            a dictionary with the following keys :
+        n_bits (Union[int, Dict[str, int]]): number of bits for quantization, can be a single value
+            or a dictionary with the following keys :
             - "op_inputs" and "op_weights" (mandatory)
             - "model_inputs" and "model_outputs" (optional, default to 5 bits).
             When using a single integer for n_bits, its value is assigned to "op_inputs" and
-            "op_weights" bits.
+            "op_weights" bits. Default is 8 bits.
         rounding_threshold_bits (int): if not None, every accumulators in the model are rounded down
             to the given bits of precision
         p_error (Optional[float]): probability of error of a single PBS


### PR DESCRIPTION
The `n_bits` configuration for `compile_torch_model` did not explain that weights&activations can have different bitwidths. I added this explanation. 

closes https://github.com/zama-ai/concrete-ml-internal/issues/2365