### PR TITLE
Fix: Error when installing in the way described by docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ To install with Docker, pull the `concrete-ml` image as follows:
 To install Concrete ML from PyPi, run the following:
 
 ```
-pip install -U pip wheel setuptools
+pip install -U pip wheel
+pip install setuptools==65.6.3
 pip install concrete-ml
 ```
 


### PR DESCRIPTION
A dependency version error happens if we run the "pip install" commands as described. Here is the message:

ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts. concrete-ml 1.1.0 requires setuptools==65.6.3, but you have setuptools 69.0.3 which is incompatible.

Since concrete-ml requires specifically the version 65.6.3, we need to specify it in the instructions.