### PR TITLE
docs: add links to credit card approval space in use case examples

### DIFF
--- a/use_case_examples/credit_card_approval_prediction/README.md
+++ b/use_case_examples/credit_card_approval_prediction/README.md
@@ -1,0 +1,3 @@
+# Encrypted Credit Card Approval Prediction Using Fully Homomorphic Encryption
+
+We have created a [Hugging Face space](https://huggingface.co/spaces/zama-fhe/credit_card_approval_prediction) to predict credit card eligibility while maintaining strict data privacy while data is encrypted end-to-end using [Concrete ML](https://github.com/zama-ai/concrete-ml). More details can be found directly in the app. All development files are available [here](https://huggingface.co/spaces/zama-fhe/credit_card_approval_prediction/tree/main).

--- a/use_case_examples/image_filtering/README.md
+++ b/use_case_examples/image_filtering/README.md
@@ -1,5 +1,5 @@
 # Image filtering using FHE
 
-Zama has created a [Hugging Face space](https://huggingface.co/spaces/zama-fhe/encrypted_image_filtering) to apply filters over images homomorphically using the developer-friendly tools in [Concrete](https://github.com/zama-ai/concrete) and [Concrete ML](https://github.com/zama-ai/concrete-ml). This means the data is encrypted both in transit and during processing.
+We have created a [Hugging Face space](https://huggingface.co/spaces/zama-fhe/encrypted_image_filtering) to apply filters over images homomorphically using the developer-friendly tools in [Concrete](https://github.com/zama-ai/concrete) and [Concrete ML](https://github.com/zama-ai/concrete-ml). This means the data is encrypted both in transit and during processing.
 
 A [tutorial](https://www.zama.ai/post/encrypted-image-filtering-using-homomorphic-encryption) has also been published alongside. It describes the few steps needed for replicating such a demo and be able to experiment with new customizable filters. All development files are available [here](https://huggingface.co/spaces/zama-fhe/encrypted_image_filtering/tree/main).


### PR DESCRIPTION
Similarly to what we've done for the image filtering space