### PR TITLE
chore: update dependabot commit message

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,6 +13,8 @@ updates:
       # Check for updates to GitHub Actions every sunday
       interval: "weekly"
       day: "sunday"
+    commit-message:
+      prefix: "chore"
 
   - package-ecosystem: "docker"
     directory: "/docker"
@@ -21,3 +23,5 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
else, CIs for dependabot failed (following the changes made last week)