### PR TITLE
chore: workaround fix pytest CI step with invalid sequence error in keras

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ setup_env:
 	poetry run python -m pip install -U --pre "$(CONCRETE_PYTHON_VERSION)"
 	"$(MAKE)" fix_omp_issues_for_intel_mac
 
-	poetry run python -c "import skorch" # Details above
+	poetry run python -c "import skorch; import keras" # Details above
 
 .PHONY: sync_env # Synchronise the environment
 sync_env: 


### PR DESCRIPTION
turns out the error we got with skorch also happened with keras in the CI when I've updated poetry : https://github.com/zama-ai/concrete-ml/actions/runs/7817775612/job/21326578294

this is annoying and hopefully adding keras to the workaround will be enough, ~~but that also means I need to fix the CI as it clearly was not supposed to be green last time~~

edit: actually the CI is fine, the issue only happened when running tests from `test_p_error_binary_search`, which we have flagged as known flaky tests. The CI properly re-ran these tests, but for some obscure reasons, no errors were raised on the second run, making the CI go green as expected.

edit bis : updating keras might be enough, I'll close this PR is https://github.com/zama-ai/concrete-ml/pull/498 works