### PR TITLE
fix: fix concurrency issue in release process

### DIFF
--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -7,7 +7,7 @@ on:
         required: true
 
 concurrency:
-  group: "Prepare release"
+  group: "Prepare Release ${{ github.event.inputs.version }}"
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ on:
 # the continuous-integration.yaml workflow currently cancels all workflows from the same group that
 # are not triggered by a push targeting main, which is the case in the release process
 concurrency:
-  group: "Release"
+  group: "Release ${{ github.ref }}"
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
In the current release process the concurrency group for release actions is just the name of the github action.
That means that we can't do a patch release and a minor release at the same, which is an issue.

I  propose to solve this by adding the github.ref to the concurrency group.

https://docs.github.com/en/actions/learn-github-actions/contexts#github-context