### PR TITLE
fix: make skorch import fail without error

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -339,13 +339,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up Python
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c
+        id: setup-python
+        with:
+          python-version: 3.8
+
       - name: Install dependencies
         run: |
           # We need to freeze docker.io because its update requires user input
           sudo apt update
           sudo apt-mark hold docker.io
 
-          ./script/make_utils/setup_os_deps.sh  --linux-install-python
+          ./script/make_utils/setup_os_deps.sh
           make setup_env
 
       - name: Set tags in env

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,7 @@ setup_env:
 	echo "Installing $(CONCRETE_PYTHON_VERSION)" && \
 	poetry run python -m pip install -U --pre "$(CONCRETE_PYTHON_VERSION)"
 	"$(MAKE)" fix_omp_issues_for_intel_mac
-
-	poetry run python -c "import skorch" # Details above
+	poetry run python -c "import skorch" || true # Details above
 
 .PHONY: sync_env # Synchronise the environment
 sync_env: 


### PR DESCRIPTION
Skorch is not available in the step of the release that launches the import of skorch.
This makes the import fail without error.