### PR TITLE
chore: include root md file when checking links in CI

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -511,6 +511,8 @@ jobs:
               - tests/seeding/test_seeding.py
             docs:
               - docs/**
+              - '*.md'
+              - LICENSE
             use_cases:
               - use_case_examples/**
             codeblocks:


### PR DESCRIPTION
When Yuxi only modified the readme, the docs + check links steps were skipped : https://github.com/zama-ai/concrete-ml/actions/runs/7873209097/job/21480124606

we should check links whenever root mardown files (+ LICENSE file) are changed as well