### PR TITLE
chore: fix link to license file in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="https://github.com/zama-ai/concrete-ml/releases"><img src="https://img.shields.io/github/v/release/zama-ai/concrete-ml?style=flat-square"></a>
-  <a href="license"><img src="https://img.shields.io/badge/License-BSD--3--Clause--Clear-%23ffb243?style=flat-square"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-BSD--3--Clause--Clear-%23ffb243?style=flat-square"></a>
   <a href="https://github.com/zama-ai/bounty-program"><img src="https://img.shields.io/badge/Contribute-Zama%20Bounty%20Program-%23ffd208?style=flat-square"></a>
 </p>
 

--- a/script/make_utils/local_link_check.py
+++ b/script/make_utils/local_link_check.py
@@ -66,7 +66,9 @@ def check_content_for_dead_links(content: str, file_path: Path) -> List[str]:
             continue
 
         if not link_path.exists():
-            errors.append(f"{file_path} contains a link to {link_path} " "that can't be found")
+            errors.append(
+                f"{file_path} contains a link to file '{link_path.resolve()}' that can't be found"
+            )
     return errors
 
 


### PR DESCRIPTION
The link was always wrong (ex: https://github.com/zama-ai/concrete-ml/actions/runs/7887169029/job/21521900852), but it looks like in some systems like macos, pathlib's `exists()` function is not case sensitive 🙂 