### PR TITLE
chore: fix small grammar error in QAT error message

### DIFF
--- a/src/concrete/ml/quantization/quantized_module.py
+++ b/src/concrete/ml/quantization/quantized_module.py
@@ -47,7 +47,7 @@ def _raise_qat_import_error(bad_qat_ops: List[Tuple[str, str]]):
         "found during calibration do not appear to be quantized. \n\n"
         + "\n".join(
             map(
-                lambda info: f"* Tensor {info[0]}, input of an {info[1]} operation",
+                lambda info: f"* Tensor {info[0]}, input of a {info[1]} operation",
                 bad_qat_ops,
             )
         )


### PR DESCRIPTION
Else, it gives a lot of messages with ` input of an Transpose operation` , `input of an Slice operation` ... !

feels more natural to use `a` instead of `an` here