### PR TITLE
fix: reinstate apidoc generated tags

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -41,6 +41,7 @@
 
 ## References
 
+<!-- auto-created, do not edit, begin -->
 - [API](references/api/README.md)
   - [concrete.ml.common.check_inputs.md](references/api/concrete.ml.common.check_inputs.md)
   - [concrete.ml.common.debugging.custom_assert.md](references/api/concrete.ml.common.debugging.custom_assert.md)
@@ -93,6 +94,7 @@
   - [concrete.ml.torch.md](references/api/concrete.ml.torch.md)
   - [concrete.ml.torch.numpy_module.md](references/api/concrete.ml.torch.numpy_module.md)
   - [concrete.ml.version.md](references/api/concrete.ml.version.md)
+<!-- auto-created, do not edit, end -->
 
 ## Explanations
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -42,6 +42,7 @@
 ## References
 
 <!-- auto-created, do not edit, begin -->
+
 - [API](references/api/README.md)
   - [concrete.ml.common.check_inputs.md](references/api/concrete.ml.common.check_inputs.md)
   - [concrete.ml.common.debugging.custom_assert.md](references/api/concrete.ml.common.debugging.custom_assert.md)
@@ -94,6 +95,7 @@
   - [concrete.ml.torch.md](references/api/concrete.ml.torch.md)
   - [concrete.ml.torch.numpy_module.md](references/api/concrete.ml.torch.numpy_module.md)
   - [concrete.ml.version.md](references/api/concrete.ml.version.md)
+
 <!-- auto-created, do not edit, end -->
 
 ## Explanations


### PR DESCRIPTION
The tags were removed by accident by editing directly on Gitbook