### PR TITLE
chore: enable local FHE execution to benchmark hybrid models

### DIFF
--- a/src/concrete/ml/torch/hybrid_model.py
+++ b/src/concrete/ml/torch/hybrid_model.py
@@ -37,6 +37,7 @@ class HybridFHEMode(enum.Enum):
     REMOTE = "remote"  # Use remote FHE server
     SIMULATE = "simulate"  # Use FHE simulation
     CALIBRATE = "calibrate"  # Use calibration (to run before FHE compilation)
+    EXECUTE = "execute"  # Use FHE execution
 
 
 def tuple_to_underscore_str(tup: Tuple) -> str:


### PR DESCRIPTION
Allow FHE local execution for hybrid model to be able to bench the execution time