### PR TITLE
chore: avoid checking for coverage in weekly tests with pypi

### DIFF
--- a/script/make_utils/pytest_pypi_cml.sh
+++ b/script/make_utils/pytest_pypi_cml.sh
@@ -88,10 +88,11 @@ if ${TEST_CODEBLOCKS}; then
 elif ${NO_FLAKY}; then
     make pytest_no_flaky
 
-# Else, intall the pytest coverage plugin and run 'pytest' 
+# Else, intall the pytest coverage plugin and run 'pytest_internal_parallel' (instead of `pytest`
+# since we don't want to check for coverage here)
 else
     python -m pip install pytest-cov==4.1.0
-    make pytest
+    make pytest_internal_parallel
 fi
 
 # Delete the virtual env directory


### PR DESCRIPTION
second step towards a green weekly CI

refs https://github.com/zama-ai/concrete-ml-internal/issues/4030
closes https://github.com/zama-ai/concrete-ml-internal/issues/4251
