### PR TITLE
fix: identify ConstantOfShape ONNX nodes as constant values

### DIFF
--- a/src/concrete/ml/quantization/post_training.py
+++ b/src/concrete/ml/quantization/post_training.py
@@ -517,7 +517,11 @@ class ONNXConverter:
             assert_true(len(node.output) == 1)
 
             output_name = node.output[0]
-            if op_type == "Constant":
+
+            # 'ConstantOfShape' ONNX nodes appear when using torch operators like `zeros_like`.
+            # Most of the time, ONNX seems to optimize the graph and remove them from it. However,
+            # that is not always the case and we need to identify them as constant values as well
+            if op_type in ["Constant", "ConstantOfShape"]:
                 constant_values = ONNX_OPS_TO_NUMPY_IMPL["Constant"](**attributes)[0]
                 node_results[output_name] = constant_values
                 constants.add(output_name)

--- a/tests/torch/test_compile_torch.py
+++ b/tests/torch/test_compile_torch.py
@@ -31,6 +31,7 @@ from concrete.ml.pytest.torch_models import (
     CNNGrouped,
     CNNOther,
     ConcatFancyIndexing,
+    ConstantOfShapeModel,
     Conv1dModel,
     DoubleQuantQATMixNet,
     EncryptedMatrixMultiplicationModel,
@@ -625,7 +626,10 @@ def test_compile_torch_qat(
 
 @pytest.mark.parametrize(
     "model_class, input_output_feature, is_brevitas_qat",
-    [pytest.param(partial(MultiInputNNDifferentSize, is_brevitas_qat=True), [5, 10], True)],
+    [
+        pytest.param(partial(MultiInputNNDifferentSize, is_brevitas_qat=True), [5, 10], True),
+        pytest.param(ConstantOfShapeModel, (1, 8, 8), True),
+    ],
 )
 @pytest.mark.parametrize(
     "n_bits",


### PR DESCRIPTION
this PR is in draft until we find a proper solution, as the initial suggestion is not right (`ConstantOfShape` are not real constants, they have an input coming in)

a model that contains a "ConstantOfShape" node can trigger an obscure `AttributeError: 'RawOpOutput' object has no attribute 'quantizer'` in the `QuantizedAdd` operator

closes https://github.com/zama-ai/concrete-ml-internal/issues/4406