### PR TITLE
chore: fix test rounding_threshold_bits

### DIFF
--- a/src/concrete/ml/common/utils.py
+++ b/src/concrete/ml/common/utils.py
@@ -636,7 +636,8 @@ def process_rounding_threshold_bits(rounding_threshold_bits):
             valid_keys = {"n_bits", "method"}
             if not valid_keys.issuperset(rounding_threshold_bits.keys()):
                 raise KeyError(
-                    f"Invalid keys in rounding_threshold_bits. Allowed keys are {valid_keys}."
+                    f"Invalid keys in rounding_threshold_bits. "
+                    f"Allowed keys are {sorted(valid_keys)}."
                 )
             n_bits_rounding = rounding_threshold_bits.get("n_bits")
             if n_bits_rounding == "auto":

--- a/tests/torch/test_compile_torch.py
+++ b/tests/torch/test_compile_torch.py
@@ -1423,7 +1423,7 @@ def test_onnx_no_input():
         (
             {"invalid_key": 4},
             KeyError,
-            "Invalid keys in rounding_threshold_bits. Allowed keys are {'n_bits', 'method'}.",
+            "Invalid keys in rounding_threshold_bits. Allowed keys are \\['method', 'n_bits'\\].",
         ),
         (
             {"n_bits": "not_an_int"},


### PR DESCRIPTION
fixing expected test error message which uses .keys() (random order)