### PR TITLE
Fixed bug in llm gpt-2 demo where simulate where not called properly causing a crash in the code because operation wasn't suported

### DIFF
--- a/use_case_examples/llm/qgpt2_class.py
+++ b/use_case_examples/llm/qgpt2_class.py
@@ -129,7 +129,7 @@ class QuantizedModel:
                 q_x = np.expand_dims(q_x, axis=0)
 
                 if fhe == "simulate":
-                    q_y = self.circuit.simulate
+                    q_y = self.circuit.simulate(q_x)
 
                 elif fhe == "execute":
                     q_y = self.circuit.encrypt_run_decrypt(q_x)


### PR DESCRIPTION
in https://github.com/zama-ai/concrete-ml/tree/release/1.5.x/use_case_examples/llm where simulate where not called properly, causing "[TypeError: unsupported operand type(s) for /: 'method' and 'int'](https://stackoverflow.com/questions/68713278/typeerror-unsupported-operand-types-for-method-and-int)" in https://github.com/zama-ai/concrete-ml/blob/release/1.5.x/use_case_examples/llm/qgpt2_class.py .