### PR TITLE
chore: add filter for FutureWarning raised by huggingface-hub 0.23

### DIFF
--- a/tests/torch/test_hybrid_converter.py
+++ b/tests/torch/test_hybrid_converter.py
@@ -101,6 +101,9 @@ def run_hybrid_llm_test(
                 assert file_name in module_dir_files
 
 
+# Dependency 'huggingface-hub' raises a 'FutureWarning' from version 0.23.0 when calling the
+# 'from_pretrained' method
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize(
     "list_or_str_private_modules_names, expected_accuracy",
     [
@@ -124,6 +127,7 @@ def test_gpt2_hybrid_mlp(list_or_str_private_modules_names, expected_accuracy):
     run_hybrid_llm_test(model, input_ids, list_or_str_private_modules_names, expected_accuracy)
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_hybrid_brevitas_qat_model():
     """Test GPT2 hybrid."""
     n_bits = 3
@@ -145,6 +149,8 @@ def test_hybrid_brevitas_qat_model():
     hybrid_model.compile_model(x=inputs)
 
 
+# Dependency 'huggingface-hub' raises a 'FutureWarning' from version 0.23.0 when calling the
+# 'from_pretrained' method
 def test_gpt2_hybrid_mlp_module_not_found():
     """Test GPT2 hybrid."""
 


### PR DESCRIPTION
let's close the associated issue but keep in mind that these warnings started to happen because poetry was somehow installing a higher version that what is written in the lock file

closes https://github.com/zama-ai/concrete-ml-internal/issues/4437