### PR TITLE
chore(ci): update usage of slab-github-runner to last version

### DIFF
--- a/.github/workflows/cifar_benchmark.yaml
+++ b/.github/workflows/cifar_benchmark.yaml
@@ -54,16 +54,16 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       runner-name: ${{ steps.start-instance.outputs.label }}
-      instance-id: ${{ steps.start-instance.outputs.ec2-instance-id }}
     steps:
       - name: Start instance
         id: start-instance
-        uses: zama-ai/slab-github-runner@ab65ad70bb9f9e9251e4915ea5612bcad23cd9b1
+        uses: zama-ai/slab-github-runner@1dced74825027fe3d481392163ed8fc56813fb5d
         with:
           mode: start
           github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
+          backend: aws
           profile: ${{ env.SLAB_PROFILE }}
 
   run-cifar-10:
@@ -211,13 +211,12 @@ jobs:
     steps:
       - name: Stop instance
         id: stop-instance
-        uses: zama-ai/slab-github-runner@ab65ad70bb9f9e9251e4915ea5612bcad23cd9b1
+        uses: zama-ai/slab-github-runner@1dced74825027fe3d481392163ed8fc56813fb5d
         with:
           mode: stop
           github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
           slab-url: ${{ secrets.SLAB_BASE_URL }}
           job-secret: ${{ secrets.JOB_SECRET }}
-          profile: ${{ env.SLAB_PROFILE }}
           label: ${{ needs.setup-ec2.outputs.runner-name }}
 
   slack-notification:

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -6,7 +6,7 @@ instance_type = "m6i.metal"
 subnet_id = "subnet-a029b7ed"
 security_group= ["sg-0bf1c1d79c97bc88f", ]
 
-[profile.big-cpu]
+[backend.aws.big-cpu]
 region = "eu-west-1"
 image_id = "ami-0898af27b3e2421d8"
 instance_type = "hpc7a.96xlarge"


### PR DESCRIPTION
With the version of Slab (and the runner associated), there is a breaking change on how a backend is handled.
This will be merged once the latest release of Slab is shipped to production. 
