### PR TITLE
chore: rename concurrency group for weekly action

### DIFF
--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -9,7 +9,7 @@ on:
     - cron: '0 22 * * 0'
 
 concurrency:
-  group: "${{ github.ref }}-${{ github.event_name }}-${{ github.workflow }}"
+  group: "${{ github.ref }}-${{ github.event_name }}-weekly-tests"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
without this, weekly tests that are manually triggered are skipped because they can conflict with the reusable CI workflow (ex: https://github.com/zama-ai/concrete-ml/actions/runs/9209078483)