### PR TITLE
chore: add transformers library in pypi wheel tests

### DIFF
--- a/ci/aws_ami_build_component.yaml
+++ b/ci/aws_ami_build_component.yaml
@@ -77,7 +77,7 @@ phases:
             - apt install -y git-lfs
             - git lfs install
             - source venv/bin/activate
-            - python -m pip install pytest==7.1.1 pandas==2.0.3 tensorflow==2.12.0 tf2onnx==1.13.0 torchvision==0.14.1
+            - python -m pip install pytest==7.1.1 pandas==2.0.3 tensorflow==2.12.0 tf2onnx==1.13.0 torchvision==0.14.1 transformers==4.40.0
 
         # We disable tests for test_deploy file because the instance does not have AWS CLI setup
       - name: RunTests

--- a/script/make_utils/pytest_pypi_cml.sh
+++ b/script/make_utils/pytest_pypi_cml.sh
@@ -51,7 +51,7 @@ source "${PYPI_VENV}/bin/activate"
 # Investigate a better way of managing these dependencies 
 # FIXME: https://github.com/zama-ai/concrete-ml-internal/issues/2685
 python -m pip install --upgrade pip
-python -m pip install pytest==7.4.1 pandas==2.0.3 tensorflow==2.12.0 tf2onnx==1.15.0 torchvision==0.14.1
+python -m pip install pytest==7.4.1 pandas==2.0.3 tensorflow==2.12.0 tf2onnx==1.15.0 torchvision==0.14.1 transformers==4.40.0
 
 # Install additional pytest plugins
 python -m pip install pytest-xdist==3.3.1


### PR DESCRIPTION
else, the weekly pypi wheel tests fail : https://github.com/zama-ai/concrete-ml/actions/runs/9220877214/job/25368925115

I believe this is happening we've recently put the transformer library as a dev dependency 