### PR TITLE
chore: fix local refs issue sync repo action

### DIFF
--- a/.github/workflows/sync_on_push.yaml
+++ b/.github/workflows/sync_on_push.yaml
@@ -26,6 +26,6 @@ jobs:
         with:
           source_repo: "zama-ai/concrete-ml"
           source_branch: "main"
-          destination_repo: "https://${{ secrets.BOT_USERNAME }}:${{ secrets.CONCRETE_ACTIONS_TOKEN }}@github.com/${{ secrets.SYNC_DEST_REPO }}"
+          destination_repo: "https://${{ secrets.BOT_USERNAME }}:${{ secrets.CONCRETE_ACTIONS_TOKEN }}@github.com/${{ secrets.SYNC_DEST_REPO }}.git"
           destination_branch: "main"
           push_lfs: true

--- a/.github/workflows/sync_on_push.yaml
+++ b/.github/workflows/sync_on_push.yaml
@@ -12,17 +12,15 @@ jobs:
     if: ${{ github.repository == 'zama-ai/concrete-ml' }}
     runs-on: ubuntu-latest
     steps:
-      # - name: Checkout repo
-      #   uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
-      #   with:
-      #     fetch-depth: 0
-      #     lfs: true
-
       # Initial action can be found here: https://github.com/wei/git-sync
-      # The issue is that it does not handle LFS files when pushing, so we had to fork it and 
-      # add the feature
+      # The issue is that it does not handle new LFS files when pushing, only the ones that are 
+      # already existing ones. We therefore had to fork it and add the feature manually. In 
+      # particular, trying to rewrite the action directly here as a step does not work because of
+      # some authorization issues and thus requires to further investigate on the right 
+      # configuration to use. This is not needed with external actions like this one as they
+      # are specifically allowed in the repository's settings
       - name: git-sync
-        uses: RomanBredehoft/git-sync@90c0b4d50224381109327f0513a7e7a90a766b2f
+        uses: RomanBredehoft/git-sync@4cb5df92a32e6b0881903ebb4e7b2e7d5643891b
         with:
           source_repo: "zama-ai/concrete-ml"
           source_branch: "main"

--- a/.github/workflows/sync_on_push.yaml
+++ b/.github/workflows/sync_on_push.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Custom git-sync
         run: |
-          PRIVATE_REPO="https://${{ secrets.BOT_USERNAME }}:${{ secrets.CONCRETE_ACTIONS_TOKEN }}@github.com/${{ secrets.SYNC_DEST_REPO }}"
+          PRIVATE_REPO="https://${{ secrets.BOT_USERNAME }}:${{ secrets.CONCRETE_ACTIONS_TOKEN }}@github.com/${{ secrets.SYNC_DEST_REPO }}.git"
 
           git remote add private_repo "$PRIVATE_REPO"
 

--- a/.github/workflows/sync_on_push.yaml
+++ b/.github/workflows/sync_on_push.yaml
@@ -12,11 +12,11 @@ jobs:
     if: ${{ github.repository == 'zama-ai/concrete-ml' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
-        with:
-          fetch-depth: 0
-          lfs: true
+      # - name: Checkout repo
+      #   uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      #   with:
+      #     fetch-depth: 0
+      #     lfs: true
 
       # Initial action can be found here: https://github.com/wei/git-sync
       # The issue is that it does not handle LFS files when pushing, so we had to fork it and 

--- a/.github/workflows/sync_on_push.yaml
+++ b/.github/workflows/sync_on_push.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Custom git-sync
         run: |
-          PRIVATE_REPO="https://${{ secrets.BOT_USERNAME }}:${{ secrets.CONCRETE_ACTIONS_TOKEN }}@github.com/${{ secrets.SYNC_DEST_REPO }}.git"
+          PRIVATE_REPO="https://${{ secrets.BOT_USERNAME }}:${{ secrets.CONCRETE_ACTIONS_TOKEN }}@github.com/${{ secrets.SYNC_DEST_REPO }}"
 
           git remote add private_repo "$PRIVATE_REPO"
 

--- a/.github/workflows/sync_on_push.yaml
+++ b/.github/workflows/sync_on_push.yaml
@@ -12,20 +12,42 @@ jobs:
     if: ${{ github.repository == 'zama-ai/concrete-ml' }}
     runs-on: ubuntu-latest
     steps:
-      # - name: Checkout repo
-      #   uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
-      #   with:
-      #     fetch-depth: 0
-      #     lfs: true
+      - name: Checkout repo
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        with:
+          fetch-depth: 0
+          lfs: true
+          ref: "main"
 
       # Initial action can be found here: https://github.com/wei/git-sync
       # The issue is that it does not handle LFS files when pushing, so we had to fork it and 
       # add the feature
-      - name: git-sync
-        uses: RomanBredehoft/git-sync@2e68fe0b118adbae6d9293ea7759227b8191e4af
-        with:
-          source_repo: "zama-ai/concrete-ml"
-          source_branch: "main"
-          destination_repo: "https://${{ secrets.BOT_USERNAME }}:${{ secrets.CONCRETE_ACTIONS_TOKEN }}@github.com/${{ secrets.SYNC_DEST_REPO }}.git"
-          destination_branch: "main"
-          push_lfs: true
+      # - name: git-sync
+      #   uses: RomanBredehoft/git-sync@2e68fe0b118adbae6d9293ea7759227b8191e4af
+      #   with:
+      #     source_repo: "zama-ai/concrete-ml"
+      #     source_branch: "main"
+      #     destination_repo: "https://${{ secrets.BOT_USERNAME }}:${{ secrets.CONCRETE_ACTIONS_TOKEN }}@github.com/${{ secrets.SYNC_DEST_REPO }}.git"
+      #     destination_branch: "main"
+      #     push_lfs: true
+
+      - name: Custom git-sync
+        run: |
+          SOURCE_BRANCH="main"
+          DESTINATION_BRANCH="main"
+
+          SOURCE_REPO="https://github.com/zama-ai/concrete-ml.git"
+          PRIVATE_REPO="https://${{ secrets.BOT_USERNAME }}:${{ secrets.CONCRETE_ACTIONS_TOKEN }}@github.com/${{ secrets.SYNC_DEST_REPO }}.git"
+
+          echo "SOURCE=$SOURCE_REPO:$SOURCE_BRANCH"
+          echo "DESTINATION=$PRIVATE_REPO:$DESTINATION_BRANCH"
+
+          git remote add private_repo "$PRIVATE_REPO"
+
+          echo "Push LFS files:"
+          # git lfs push private_repo "${SOURCE_BRANCH}:${DESTINATION_BRANCH}"
+          git lfs push private_repo main --dry-run
+
+          echo "Push remaining files:"
+          # git push private_repo "${SOURCE_BRANCH}:${DESTINATION_BRANCH}" -f
+          git push private_repo -f main --dry-run

--- a/.github/workflows/sync_on_push.yaml
+++ b/.github/workflows/sync_on_push.yaml
@@ -19,34 +19,15 @@ jobs:
           lfs: true
           ref: "main"
 
-      # Initial action can be found here: https://github.com/wei/git-sync
-      # The issue is that it does not handle LFS files when pushing, so we had to fork it and 
-      # add the feature
-      # - name: git-sync
-      #   uses: RomanBredehoft/git-sync@2e68fe0b118adbae6d9293ea7759227b8191e4af
-      #   with:
-      #     source_repo: "zama-ai/concrete-ml"
-      #     source_branch: "main"
-      #     destination_repo: "https://${{ secrets.BOT_USERNAME }}:${{ secrets.CONCRETE_ACTIONS_TOKEN }}@github.com/${{ secrets.SYNC_DEST_REPO }}.git"
-      #     destination_branch: "main"
-      #     push_lfs: true
-
       - name: Custom git-sync
         run: |
-          SOURCE_BRANCH="main"
-          DESTINATION_BRANCH="main"
-
-          SOURCE_REPO="https://github.com/zama-ai/concrete-ml.git"
           PRIVATE_REPO="https://${{ secrets.BOT_USERNAME }}:${{ secrets.CONCRETE_ACTIONS_TOKEN }}@github.com/${{ secrets.SYNC_DEST_REPO }}.git"
-
-          echo "SOURCE=$SOURCE_REPO:$SOURCE_BRANCH"
-          echo "DESTINATION=$PRIVATE_REPO:$DESTINATION_BRANCH"
 
           git remote add private_repo "$PRIVATE_REPO"
 
           echo "Push LFS files:"
           # git lfs push private_repo "${SOURCE_BRANCH}:${DESTINATION_BRANCH}"
-          git lfs push private_repo main --dry-run
+          # git lfs push private_repo main --dry-run
 
           echo "Push remaining files:"
           # git push private_repo "${SOURCE_BRANCH}:${DESTINATION_BRANCH}" -f

--- a/.github/workflows/sync_on_push.yaml
+++ b/.github/workflows/sync_on_push.yaml
@@ -12,23 +12,20 @@ jobs:
     if: ${{ github.repository == 'zama-ai/concrete-ml' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      # - name: Checkout repo
+      #   uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      #   with:
+      #     fetch-depth: 0
+      #     lfs: true
+
+      # Initial action can be found here: https://github.com/wei/git-sync
+      # The issue is that it does not handle LFS files when pushing, so we had to fork it and 
+      # add the feature
+      - name: git-sync
+        uses: RomanBredehoft/git-sync@3b692f6f09e921cfc7add7e1d0f7a54d7fe5f6ac
         with:
-          fetch-depth: 0
-          lfs: true
-          ref: "main"
-
-      - name: Custom git-sync
-        run: |
-          PRIVATE_REPO="https://${{ secrets.BOT_USERNAME }}:${{ secrets.CONCRETE_ACTIONS_TOKEN }}@github.com/${{ secrets.SYNC_DEST_REPO }}.git"
-
-          git remote add private_repo "$PRIVATE_REPO"
-
-          echo "Push LFS files:"
-          # git lfs push private_repo "${SOURCE_BRANCH}:${DESTINATION_BRANCH}"
-          # git lfs push private_repo main --dry-run
-
-          echo "Push remaining files:"
-          # git push private_repo "${SOURCE_BRANCH}:${DESTINATION_BRANCH}" -f
-          git push private_repo -f main --dry-run
+          source_repo: "zama-ai/concrete-ml"
+          source_branch: "main"
+          destination_repo: "https://${{ secrets.BOT_USERNAME }}:${{ secrets.CONCRETE_ACTIONS_TOKEN }}@github.com/${{ secrets.SYNC_DEST_REPO }}.git"
+          destination_branch: "main"
+          push_lfs: true

--- a/.github/workflows/sync_on_push.yaml
+++ b/.github/workflows/sync_on_push.yaml
@@ -22,7 +22,7 @@ jobs:
       # The issue is that it does not handle LFS files when pushing, so we had to fork it and 
       # add the feature
       - name: git-sync
-        uses: RomanBredehoft/git-sync@3b692f6f09e921cfc7add7e1d0f7a54d7fe5f6ac
+        uses: RomanBredehoft/git-sync@90c0b4d50224381109327f0513a7e7a90a766b2f
         with:
           source_repo: "zama-ai/concrete-ml"
           source_branch: "main"

--- a/.github/workflows/sync_on_push.yaml
+++ b/.github/workflows/sync_on_push.yaml
@@ -22,7 +22,7 @@ jobs:
       # The issue is that it does not handle LFS files when pushing, so we had to fork it and 
       # add the feature
       - name: git-sync
-        uses: RomanBredehoft/git-sync@836de2d057c5bfae184bc4d45160463fe8653796
+        uses: RomanBredehoft/git-sync@2e68fe0b118adbae6d9293ea7759227b8191e4af
         with:
           source_repo: "zama-ai/concrete-ml"
           source_branch: "main"


### PR DESCRIPTION
the fix has been made in the git-sync fork : https://github.com/RomanBredehoft/git-sync/commit/90c0b4d50224381109327f0513a7e7a90a766b2f

the reason was that we were pushing lfs files using 
```
git lfs push destination "${SOURCE_BRANCH}:${DESTINATION_BRANCH}"
```
but normally LFS only handles a single destination refs (https://github.com/git-lfs/git-lfs/blob/main/docs/man/git-lfs-push.adoc) like : 
```
git lfs push destination "${DESTINATION_BRANCH}"
```
but for some reasons, the error just recently showed up

closes https://github.com/zama-ai/concrete-ml-internal/issues/4445