### PR TITLE
chore: fix wheel install in weekly CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -518,7 +518,7 @@ pytest_codeblocks:
 
 .PHONY: pytest_codeblocks_pypi_wheel_cml # Test code blocks using the PyPI local wheel of Concrete ML
 pytest_codeblocks_pypi_wheel_cml:
-	./script/make_utils/pytest_pypi_cml.sh --wheel "$(CONCRETE_PYTHON_VERSION)" --codeblocks
+	./script/make_utils/pytest_pypi_cml.sh --wheel --codeblocks
 
 .PHONY: pytest_codeblocks_pypi_cml # Test code blocks using PyPI Concrete ML
 pytest_codeblocks_pypi_cml:
@@ -761,11 +761,11 @@ check_unused_images:
 
 .PHONY: pytest_pypi_wheel_cml # Run tests using PyPI local wheel of Concrete ML
 pytest_pypi_wheel_cml:
-	./script/make_utils/pytest_pypi_cml.sh --wheel "$(CONCRETE_PYTHON_VERSION)"
+	./script/make_utils/pytest_pypi_cml.sh --wheel
 
 .PHONY: pytest_pypi_wheel_cml_no_flaky # Run tests (except flaky ones) using PyPI local wheel of Concrete ML
 pytest_pypi_wheel_cml_no_flaky:
-	./script/make_utils/pytest_pypi_cml.sh --wheel "$(CONCRETE_PYTHON_VERSION)" --noflaky
+	./script/make_utils/pytest_pypi_cml.sh --wheel --noflaky
 
 .PHONY: pytest_pypi_cml # Run tests using PyPI Concrete ML
 pytest_pypi_cml:

--- a/script/make_utils/check_installation_with_all_python.sh
+++ b/script/make_utils/check_installation_with_all_python.sh
@@ -75,7 +75,7 @@ do
 
         # Install the dependencies as PyPI would do using the wheel file
         PYPI_WHEEL=$(find dist -type f -name "*.whl")
-        python -m pip install "${PYPI_WHEEL}"
+        python -m pip install --extra-index-url https://pypi.zama.ai "${PYPI_WHEEL}"
 
     elif [ "$METHOD" == "pip" ]
     then

--- a/script/make_utils/pytest_pypi_cml.sh
+++ b/script/make_utils/pytest_pypi_cml.sh
@@ -12,8 +12,6 @@ do
    case "$1" in
         "--wheel" )
             USE_PIP_WHEEL='true'
-            shift
-            CONCRETE_PYTHON="$1"
             ;;
         
         "--codeblocks" )
@@ -68,8 +66,7 @@ if ${USE_PIP_WHEEL}; then
     # Install the dependencies as PyPI would do using the wheel file as well as the given
     # Concrete-Python version
     PYPI_WHEEL=$(find dist -type f -name "*.whl")
-    python -m pip install "${PYPI_WHEEL}"
-    python -m pip install --extra-index-url https://pypi.zama.ai "${CONCRETE_PYTHON}"
+    python -m pip install --extra-index-url https://pypi.zama.ai "${PYPI_WHEEL}"
 else
     if [ -z "${VERSION}" ]; then
         python -m pip install concrete-ml


### PR DESCRIPTION
the weekly crashes because of the `pip install` was missing some `--extra-index-url` for Concrete Python when installing wheels (https://github.com/zama-ai/concrete-ml/actions/runs/9386053499/job/25845972848)

there's probably a way of enabling it for all pip commands in the project but I couldn't find a proper and easy solution, so let's do that for now 