### PR TITLE
chore: activate input compression for encrypted data-frames [BLOCKED BY CP]

### DIFF
--- a/src/concrete/ml/pandas/_development.py
+++ b/src/concrete/ml/pandas/_development.py
@@ -164,12 +164,12 @@ def save_client_server(client_path: Path = CLIENT_PATH, server_path: Path = SERV
     # Get the input-set and circuit generating functions
     inputset = config["get_inputset"]()
     cp_func = config["to_compile"]
-    compilation_configuration = Configuration(compress_evaluation_keys=True)
+    configuration = Configuration(
+        composable=True, compress_evaluation_keys=True, compress_input_ciphertexts=True
+    )
 
     # Compile the circuit and allow it to be composable with itself
-    merge_circuit = cp_func.compile(
-        inputset, composable=True, configuration=compilation_configuration
-    )
+    merge_circuit = cp_func.compile(inputset, configuration=configuration)
 
     # Save the client and server files using the MLIR
     merge_circuit.client.save(client_path)

--- a/tests/torch/test_hybrid_converter.py
+++ b/tests/torch/test_hybrid_converter.py
@@ -37,17 +37,9 @@ def run_hybrid_llm_test(
 ):
     """Run the test for any model with its private module names."""
 
-    # Multi-parameter strategy is used in order to speed-up the FHE executions
-    configuration = Configuration(
-        single_precision=False,
-        compress_input_ciphertexts=True,
-    )
-
     # Create a hybrid model
     hybrid_model = HybridFHEModel(model, module_names)
-    hybrid_model.compile_model(
-        inputs, p_error=0.01, n_bits=8, rounding_threshold_bits=8, configuration=configuration
-    )
+    hybrid_model.compile_model(inputs, p_error=0.01, n_bits=8, rounding_threshold_bits=8)
 
     # Check we can run the simulate locally
     logits_simulate = hybrid_model(inputs, fhe="simulate").logits

--- a/tests/torch/test_hybrid_converter.py
+++ b/tests/torch/test_hybrid_converter.py
@@ -6,7 +6,6 @@ from typing import List, Union
 
 import pytest
 import torch
-from concrete.fhe import Configuration
 from transformers import GPT2LMHeadModel, GPT2Tokenizer
 
 from concrete.ml.pytest.torch_models import PartialQATModel


### PR DESCRIPTION
We realized with @andrei-stoian-zama that encrypted data-frames did not have the input compression feature activated 

this is currently blocked by https://github.com/zama-ai/concrete-internal/issues/758