### PR TITLE
chore: filter jax DeprecationWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ filterwarnings = [
     "ignore:Liblinear failed to converge,*:sklearn.exceptions.ConvergenceWarning",
     "ignore:lbfgs failed to converge,*:sklearn.exceptions.ConvergenceWarning",
     "ignore:Maximum number of iteration reached before convergence.*:sklearn.exceptions.ConvergenceWarning",
+    "ignore:jax.xla_computation is deprecated. Please use the AOT APIs.",
 ]
 
 [tool.semantic_release]


### PR DESCRIPTION
this warning made the release CI for python 3.9 and 3.10 fail : 
- https://github.com/zama-ai/concrete-ml/actions/runs/9599832121/job/26475425698
- https://github.com/zama-ai/concrete-ml/actions/runs/9599832121/job/26475426012