### PR TITLE
chore: remove provenance need in build status

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -943,7 +943,7 @@ jobs:
   # and therefore expensive macOS testing
   linux-build-status:
     name: Build Status (Linux)
-    needs: [build-linux, provenance]
+    needs: [build-linux]
     runs-on: ubuntu-20.04
     timeout-minutes: 2
     if: success() || failure()


### PR DESCRIPTION
At the moment if provenance is skipped the build-status step is also skipped because it was in the needs parameter.

This blocked the PRs so should be removed.