### PR TITLE
chore: fix wheel steps in weekly tests

### DIFF
--- a/script/make_utils/pytest_pypi_cml.sh
+++ b/script/make_utils/pytest_pypi_cml.sh
@@ -52,6 +52,9 @@ python -m pip install --upgrade pip
 if ${USE_PIP_WHEEL}; then
     # Delete the directory where the pypi wheel file will be created (if it already exists)
     rm -rf dist
+    
+    # Install dev dependencies for testing
+    poetry install --only dev
 
     # Build the wheel file
     poetry build -f wheel
@@ -61,8 +64,6 @@ if ${USE_PIP_WHEEL}; then
     PYPI_WHEEL=$(find dist -type f -name "*.whl")
     python -m pip install --extra-index-url https://pypi.zama.ai/cpu "${PYPI_WHEEL}"
 
-    # Install dev dependencies for testing
-    poetry install --only dev
 else
     if [ -z "${VERSION}" ]; then
         python -m pip install concrete-ml[dev]


### PR DESCRIPTION
not sure why this issue (https://github.com/zama-ai/concrete-ml/actions/runs/10343073361/job/28626854301) didn't happen last time I tried locally, now it should really fix the weekly ci