### PR TITLE
Relax python version restrictions

### DIFF
--- a/src/concrete/ml/deployment/fhe_client_server.py
+++ b/src/concrete/ml/deployment/fhe_client_server.py
@@ -64,6 +64,7 @@ def check_concrete_versions(zip_path: Path):
     """
 
     with zipfile.ZipFile(zip_path) as zip_file:
+        is_mlir = "circuit.mlir" in zip_file.namelist()
         with zip_file.open("versions.json", mode="r") as file:
             versions = json.load(file)
 
@@ -91,14 +92,15 @@ def check_concrete_versions(zip_path: Path):
             + "\n".join(f"{error[0]}: {error[1]} != {error[2]}" for error in errors)
         )
 
-    # Raise an error if the Python version do not match the one currently installed
-    if not versions["python"].startswith(
-        f"{sys.version_info.major}.{sys.version_info.minor}"
-    ):  # pragma: no cover
-        raise ValueError(
-            "Not the same Python version between the compiler and the server."
-            f"{versions['python']} != {sys.version_info.major}.{sys.version_info.minor}"
-        )
+    if not is_mlir:
+        # Raise an error if the Python version do not match the one currently installed
+        if not versions["python"].startswith(
+            f"{sys.version_info.major}.{sys.version_info.minor}"
+        ):  # pragma: no cover
+            raise ValueError(
+                "Not the same Python version between the compiler and the server."
+                f"{versions['python']} != {sys.version_info.major}.{sys.version_info.minor}"
+            )
 
 
 class FHEModelServer:


### PR DESCRIPTION
https://github.com/jdmarsh

> I have a client/server setup where we use the via_mlir flag to save/load the circuit. When the server.zip is generated with a different python version to what the server is running, this python version restriction prevents us from continuing. As long as the concrete/concrete-ml versions are identical, I don't see why the python version should restrict us from loading the MLIR in server side (Or why it should apply as a restriction even when not using via_mlir?). I've made a change to relax the python version restriction server side for MLIR cases.
> 
> | Please let me know if there is a good reason for this restriction to apply when sending an MLIR server.zip generated with a different python version. In that case I will find another way forward.

Closes https://github.com/zama-ai/concrete-ml-internal/issues/4280