### PR TITLE
add monkeypatch context to test_load_fitted_sklearn_tree_models

### DIFF
--- a/tests/sklearn/test_sklearn_models.py
+++ b/tests/sklearn/test_sklearn_models.py
@@ -1106,191 +1106,201 @@ def test_load_fitted_sklearn_tree_models(
     """Test `from_sklearn_model` functionnality of tree-based models."""
 
     numpy.random.seed(0)
-    os.environ["TREES_USE_ROUNDING"] = str(int(use_rounding))
+    with pytest.MonkeyPatch.context() as mp_context:
+        mp_context.setenv("TREES_USE_ROUNDING", str(int(use_rounding)))
 
-    x, y = get_dataset(
-        model_class, parameters, min(N_BITS_REGULAR_BUILDS), load_data, is_weekly_option
-    )
+        x, y = get_dataset(
+            model_class, parameters, min(N_BITS_REGULAR_BUILDS), load_data, is_weekly_option
+        )
 
-    if verbose:
-        print("Run check_load_pre_trained_sklearn_models")
+        if verbose:
+            print("Run check_load_pre_trained_sklearn_models")
 
-    assert issubclass(model_class, BaseTreeEstimatorMixin)
-    concrete_model = instantiate_model_generic(model_class, n_bits=min(N_BITS_REGULAR_BUILDS))
-    # Fit the model and retrieve both the Concrete ML and the scikit-learn models
-    with warnings.catch_warnings():
-        # Sometimes, we miss convergence, which is not a problem for our test
-        warnings.simplefilter("ignore", category=ConvergenceWarning)
-        concrete_model, sklearn_model = concrete_model.fit_benchmark(x, y)
+        assert issubclass(model_class, BaseTreeEstimatorMixin)
+        concrete_model = instantiate_model_generic(model_class, n_bits=min(N_BITS_REGULAR_BUILDS))
+        # Fit the model and retrieve both the Concrete ML and the scikit-learn models
+        with warnings.catch_warnings():
+            # Sometimes, we miss convergence, which is not a problem for our test
+            warnings.simplefilter("ignore", category=ConvergenceWarning)
+            concrete_model, sklearn_model = concrete_model.fit_benchmark(x, y)
 
-    # This step is needed in order to handle partial classes
-    model_class = get_model_class(model_class)
-    max_n_bits = 18
-    reasonable_n_bits = 10
+        # This step is needed in order to handle partial classes
+        model_class = get_model_class(model_class)
+        max_n_bits = 18
+        reasonable_n_bits = 10
 
-    if is_model_class_in_a_list(
-        model_class,
-        _get_sklearn_tree_models(classifier=True, regressor=False),
-    ):
-        for n_bits, cml_tolerance, sklearn_tolerance in [
-            (max_n_bits, 1e-1, 1e-7),
-            (reasonable_n_bits, 6e-2, 6e-2),
-        ]:
-            # Load a Concrete ML model from the fitted scikit-learn one
-            loaded_from_threshold = model_class.from_sklearn_model(
-                sklearn_model,
-                X=None,
-                n_bits=n_bits,
-            )
-
-            loaded_from_data = model_class.from_sklearn_model(
-                sklearn_model,
-                X=x,
-                n_bits=n_bits,
-            )
-
-            # Compile both the initial Concrete ML model and the loaded one
-            concrete_model.compile(x)
-            mode = "disable"
-            if n_bits <= reasonable_n_bits:
-                mode = "simulate"
-                loaded_from_threshold.compile(x)
-                loaded_from_data.compile(x)
-
-            # Compute and compare the predictions from both models
-            # Classifiers
-
-            # Predict with all models
-            sklearn_pred = sklearn_model.predict_proba(x)
-            cml_y_pred = concrete_model.predict_proba(
-                x,
-                fhe=mode,
-            )
-            cml_threshold_y_pred = loaded_from_threshold.predict_proba(
-                x,
-                fhe=mode,
-            )
-            cml_data_y_pred = loaded_from_data.predict_proba(
-                x,
-                fhe=mode,
-            )
-
-            # Compute accuracy
-            sklearn_accuracy = accuracy_score(sklearn_pred.argmax(axis=1), y)
-            cml_accuracy = accuracy_score(cml_y_pred.argmax(axis=1), y)
-            loaded_accuracy_from_threshold_accuracy = accuracy_score(
-                cml_threshold_y_pred.argmax(axis=1), y
-            )
-            loaded_accuracy_from_data_accuracy = accuracy_score(cml_data_y_pred.argmax(axis=1), y)
-
-            # Compare with sklearn
-            with subtests.test(
-                msg="Classifier Sklearn vs Threshold", n_bits=n_bits, tolerance=sklearn_tolerance
-            ):
-                value = numpy.abs(loaded_accuracy_from_threshold_accuracy - sklearn_accuracy)
-                assert (
-                    value < sklearn_tolerance
-                ), f"{loaded_accuracy_from_threshold_accuracy=} != {sklearn_accuracy} ({value})"
-            with subtests.test(
-                msg="Classifier Sklearn vs Data", n_bits=n_bits, tolerance=sklearn_tolerance
-            ):
-                value = numpy.abs(loaded_accuracy_from_data_accuracy - sklearn_accuracy)
-                assert (
-                    value < sklearn_tolerance
-                ), f"{loaded_accuracy_from_data_accuracy=} != {sklearn_accuracy} ({value})"
-
-            # Compare with CML final metric
-            with subtests.test(
-                msg="Classifier CML vs Threshold", n_bits=n_bits, tolerance=cml_tolerance
-            ):
-                value = numpy.abs(loaded_accuracy_from_threshold_accuracy - cml_accuracy)
-                assert (
-                    value < cml_tolerance
-                ), f"{loaded_accuracy_from_threshold_accuracy=} != {cml_accuracy} ({value})"
-            with subtests.test(
-                msg="Classifier CML vs Data", n_bits=n_bits, tolerance=cml_tolerance
-            ):
-                value = numpy.abs(loaded_accuracy_from_data_accuracy - cml_accuracy)
-                assert (
-                    value < cml_tolerance
-                ), f"{loaded_accuracy_from_data_accuracy=} != {cml_accuracy} ({value})"
-
-    # Regressor
-    elif is_model_class_in_a_list(
-        model_class,
-        _get_sklearn_tree_models(regressor=True, classifier=False),
-    ):
-        for n_bits, cml_tolerance, sklearn_tolerance in [
-            (max_n_bits, 0.8, 1e-5),
-            (reasonable_n_bits, 1.8, 1.8),
-        ]:
-            # Load a Concrete ML model from the fitted scikit-learn one
-            loaded_from_threshold = model_class.from_sklearn_model(
-                sklearn_model,
-                n_bits=n_bits,
-            )
-
-            loaded_from_data = model_class.from_sklearn_model(
-                sklearn_model,
-                X=x,
-                n_bits=n_bits,
-            )
-
-            # Compile both the initial Concrete ML model and the loaded one
-            concrete_model.compile(x)
-            mode = "disable"
-            if n_bits <= reasonable_n_bits:
-                mode = "simulate"
-                loaded_from_threshold.compile(x)
-                loaded_from_data.compile(x)
-
-            # Compute and compare the predictions from both models
-            # Regressors
-
-            # Predict
-            sklearn_pred = sklearn_model.predict(x)
-            cml_y_pred = concrete_model.predict(x, fhe=mode)
-            cml_threshold_y_pred = loaded_from_threshold.predict(x, fhe=mode)
-            cml_data_y_pred = loaded_from_data.predict(x, fhe=mode)
-
-            # Compute metric
-            sklearn_mse = mean_squared_error(sklearn_pred, y)
-            cml_mse = mean_squared_error(cml_y_pred, y)
-            loaded_mse_from_threshold_mse = mean_squared_error(cml_threshold_y_pred, y)
-            loaded_mse_from_data_mse = mean_squared_error(cml_data_y_pred, y)
-
-            # Compare with scikit-learn
-            with subtests.test(
-                msg="Regression Sklearn vs Threshold", n_bits=n_bits, tolerance=sklearn_tolerance
-            ):
-                value = numpy.abs(loaded_mse_from_threshold_mse - sklearn_mse) / numpy.abs(y).max()
-                assert value < sklearn_tolerance, (
-                    f"{loaded_mse_from_threshold_mse=} != {sklearn_mse} "
-                    f"({value=}>={sklearn_tolerance=})"
+        if is_model_class_in_a_list(
+            model_class,
+            _get_sklearn_tree_models(classifier=True, regressor=False),
+        ):
+            for n_bits, cml_tolerance, sklearn_tolerance in [
+                (max_n_bits, 1e-1, 1e-7),
+                (reasonable_n_bits, 6e-2, 6e-2),
+            ]:
+                # Load a Concrete ML model from the fitted scikit-learn one
+                loaded_from_threshold = model_class.from_sklearn_model(
+                    sklearn_model,
+                    X=None,
+                    n_bits=n_bits,
                 )
-            with subtests.test(
-                msg="Regression Sklearn vs Data", n_bits=n_bits, tolerance=sklearn_tolerance
-            ):
-                value = numpy.abs(loaded_mse_from_data_mse - sklearn_mse) / numpy.abs(y).max()
-                assert (
-                    value < sklearn_tolerance
-                ), f"{loaded_mse_from_data_mse=} != {sklearn_mse} ({value=}>={sklearn_tolerance=})"
 
-            # Compare with Concrete ML
-            with subtests.test(
-                msg="Regression CML vs Threshold", n_bits=n_bits, tolerance=cml_tolerance
-            ):
-                value = numpy.abs(loaded_mse_from_threshold_mse - cml_mse) / numpy.abs(y).max()
-                assert (
-                    value < cml_tolerance
-                ), f"{loaded_mse_from_threshold_mse=} != {cml_mse} ({value=}>={cml_tolerance=})"
-            with subtests.test(
-                msg="Regression CML vs Data", n_bits=n_bits, tolerance=cml_tolerance
-            ):
-                value = numpy.abs(loaded_mse_from_data_mse - cml_mse) / numpy.abs(y).max()
-                assert value < cml_tolerance, (
-                    f"{loaded_mse_from_data_mse=} !=" f" {cml_mse} ({value=}>={cml_tolerance=})"
+                loaded_from_data = model_class.from_sklearn_model(
+                    sklearn_model,
+                    X=x,
+                    n_bits=n_bits,
                 )
+
+                # Compile both the initial Concrete ML model and the loaded one
+                concrete_model.compile(x)
+                mode = "disable"
+                if n_bits <= reasonable_n_bits:
+                    mode = "simulate"
+                    loaded_from_threshold.compile(x)
+                    loaded_from_data.compile(x)
+
+                # Compute and compare the predictions from both models
+                # Classifiers
+
+                # Predict with all models
+                sklearn_pred = sklearn_model.predict_proba(x)
+                cml_y_pred = concrete_model.predict_proba(
+                    x,
+                    fhe=mode,
+                )
+                cml_threshold_y_pred = loaded_from_threshold.predict_proba(
+                    x,
+                    fhe=mode,
+                )
+                cml_data_y_pred = loaded_from_data.predict_proba(
+                    x,
+                    fhe=mode,
+                )
+
+                # Compute accuracy
+                sklearn_accuracy = accuracy_score(sklearn_pred.argmax(axis=1), y)
+                cml_accuracy = accuracy_score(cml_y_pred.argmax(axis=1), y)
+                loaded_accuracy_from_threshold_accuracy = accuracy_score(
+                    cml_threshold_y_pred.argmax(axis=1), y
+                )
+                loaded_accuracy_from_data_accuracy = accuracy_score(
+                    cml_data_y_pred.argmax(axis=1), y
+                )
+
+                # Compare with sklearn
+                with subtests.test(
+                    msg="Classifier Sklearn vs Threshold",
+                    n_bits=n_bits,
+                    tolerance=sklearn_tolerance,
+                ):
+                    value = numpy.abs(loaded_accuracy_from_threshold_accuracy - sklearn_accuracy)
+                    assert (
+                        value < sklearn_tolerance
+                    ), f"{loaded_accuracy_from_threshold_accuracy=} != {sklearn_accuracy} ({value})"
+                with subtests.test(
+                    msg="Classifier Sklearn vs Data", n_bits=n_bits, tolerance=sklearn_tolerance
+                ):
+                    value = numpy.abs(loaded_accuracy_from_data_accuracy - sklearn_accuracy)
+                    assert (
+                        value < sklearn_tolerance
+                    ), f"{loaded_accuracy_from_data_accuracy=} != {sklearn_accuracy} ({value})"
+
+                # Compare with CML final metric
+                with subtests.test(
+                    msg="Classifier CML vs Threshold", n_bits=n_bits, tolerance=cml_tolerance
+                ):
+                    value = numpy.abs(loaded_accuracy_from_threshold_accuracy - cml_accuracy)
+                    assert (
+                        value < cml_tolerance
+                    ), f"{loaded_accuracy_from_threshold_accuracy=} != {cml_accuracy} ({value})"
+                with subtests.test(
+                    msg="Classifier CML vs Data", n_bits=n_bits, tolerance=cml_tolerance
+                ):
+                    value = numpy.abs(loaded_accuracy_from_data_accuracy - cml_accuracy)
+                    assert (
+                        value < cml_tolerance
+                    ), f"{loaded_accuracy_from_data_accuracy=} != {cml_accuracy} ({value})"
+
+        # Regressor
+        elif is_model_class_in_a_list(
+            model_class,
+            _get_sklearn_tree_models(regressor=True, classifier=False),
+        ):
+            for n_bits, cml_tolerance, sklearn_tolerance in [
+                (max_n_bits, 0.8, 1e-5),
+                (reasonable_n_bits, 1.8, 1.8),
+            ]:
+                # Load a Concrete ML model from the fitted scikit-learn one
+                loaded_from_threshold = model_class.from_sklearn_model(
+                    sklearn_model,
+                    n_bits=n_bits,
+                )
+
+                loaded_from_data = model_class.from_sklearn_model(
+                    sklearn_model,
+                    X=x,
+                    n_bits=n_bits,
+                )
+
+                # Compile both the initial Concrete ML model and the loaded one
+                concrete_model.compile(x)
+                mode = "disable"
+                if n_bits <= reasonable_n_bits:
+                    mode = "simulate"
+                    loaded_from_threshold.compile(x)
+                    loaded_from_data.compile(x)
+
+                # Compute and compare the predictions from both models
+                # Regressors
+
+                # Predict
+                sklearn_pred = sklearn_model.predict(x)
+                cml_y_pred = concrete_model.predict(x, fhe=mode)
+                cml_threshold_y_pred = loaded_from_threshold.predict(x, fhe=mode)
+                cml_data_y_pred = loaded_from_data.predict(x, fhe=mode)
+
+                # Compute metric
+                sklearn_mse = mean_squared_error(sklearn_pred, y)
+                cml_mse = mean_squared_error(cml_y_pred, y)
+                loaded_mse_from_threshold_mse = mean_squared_error(cml_threshold_y_pred, y)
+                loaded_mse_from_data_mse = mean_squared_error(cml_data_y_pred, y)
+
+                # Compare with scikit-learn
+                with subtests.test(
+                    msg="Regression Sklearn vs Threshold",
+                    n_bits=n_bits,
+                    tolerance=sklearn_tolerance,
+                ):
+                    value = (
+                        numpy.abs(loaded_mse_from_threshold_mse - sklearn_mse) / numpy.abs(y).max()
+                    )
+                    assert value < sklearn_tolerance, (
+                        f"{loaded_mse_from_threshold_mse=} != {sklearn_mse} "
+                        f"({value=}>={sklearn_tolerance=})"
+                    )
+                with subtests.test(
+                    msg="Regression Sklearn vs Data", n_bits=n_bits, tolerance=sklearn_tolerance
+                ):
+                    value = numpy.abs(loaded_mse_from_data_mse - sklearn_mse) / numpy.abs(y).max()
+                    assert value < sklearn_tolerance, (
+                        f"{loaded_mse_from_data_mse=} != {sklearn_mse}"
+                        f"({value=}>={sklearn_tolerance=})"
+                    )
+
+                # Compare with Concrete ML
+                with subtests.test(
+                    msg="Regression CML vs Threshold", n_bits=n_bits, tolerance=cml_tolerance
+                ):
+                    value = numpy.abs(loaded_mse_from_threshold_mse - cml_mse) / numpy.abs(y).max()
+                    assert (
+                        value < cml_tolerance
+                    ), f"{loaded_mse_from_threshold_mse=} != {cml_mse} ({value=}>={cml_tolerance=})"
+                with subtests.test(
+                    msg="Regression CML vs Data", n_bits=n_bits, tolerance=cml_tolerance
+                ):
+                    value = numpy.abs(loaded_mse_from_data_mse - cml_mse) / numpy.abs(y).max()
+                    assert value < cml_tolerance, (
+                        f"{loaded_mse_from_data_mse=} !=" f" {cml_mse} ({value=}>={cml_tolerance=})"
+                    )
 
 
 def check_load_fitted_sklearn_linear_models(model_class, n_bits, x, y, check_float_array_equal):


### PR DESCRIPTION
This bug was reported by the [Concrete team](https://zama-ai.slack.com/archives/C044G400J6N/p1726212715764299), who encountered an issue with the value of the environment variable “TREE_USE_ROUNDING” during their tests.

The TREE_USE_ROUNDING variable is set to “1” by default in our source code, which means that tree-based models are always used with the rounding feature enabled.

However, in our Pytest tests (tests/sklearn/test_sklearn_models.py), particularly in the tests “test_load_fitted_sklearn_tree_models” and “check_rounding_consistency”, we temporarily change the value of this variable to test the rounding consistency feature.


So, the 2 tests mentioned above can conflict if they are executed in parallel, as both modify the TREE_USE_ROUNDING variable. To isolate the changes and ensure they only impact the specific test, it is recommended to use  a monkeypatch when safely modifying environment variables and  avoid potential conflicts during tests.

Hence, adding a monkeypath to "test_load_fitted_sklearn_tree_models" function (as in "check_rounding_consistency").
