### PR TITLE
chore: fixing a typo

### DIFF
--- a/use_case_examples/deployment/server/README.md
+++ b/use_case_examples/deployment/server/README.md
@@ -10,8 +10,8 @@ We show-case how to do this on 3 examples:
 You can run these example locally using Docker, or on AWS if you have your credentials set up.
 
 For all of them the workflow is the same:
-0\. Optional: Train the model
 
+1. Optional: Train the model
 1. Compile the model to an FHE circuit
 1. Deploy to AWS, Docker or localhost
 1. Run the inference using the client (locally or in Docker)


### PR DESCRIPTION
Had a look to https://github.com/zama-ai/concrete-ml/tree/main/use_case_examples/deployment/server and I think there is a typo.

By the way: maybe we are missing a README in https://github.com/zama-ai/concrete-ml/tree/main/use_case_examples/deployment/? Should we move https://github.com/zama-ai/concrete-ml/tree/main/use_case_examples/deployment/server/README there? Or have another one?

It's because people say they have difficulties in deploying, see https://discord.com/channels/901152454077452399/901152454622740593/1285222791104303134 and further messages.