### PR TITLE
chore: renaming the notebook for more clarity

### DIFF
--- a/docs/advanced_examples/LogisticRegressionTraining.ipynb
+++ b/docs/advanced_examples/LogisticRegressionTraining.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Logistic Regression Training\n",
+    "# Logistic Regression Training on Encrypted Dataset\n",
     "\n",
     "This notebook shows how to train a logistic regression model on encrypted data using stochastic gradient descent (SGD). During this process,\n",
     "the training set remains encrypted at all times and the gradients and loss are encrypted, thus unaccessible by the server performing the training. \n",


### PR DESCRIPTION
The notebook had no obvious "FHE training" aspect in its name or in its title (Logistic Regression Training). I think it's a bit misleading for the quick readers, isn't it? Changing the name of the file is bad, it may break links, but what about changing its title to something like "Logistic Regression Training Over Encrypted Dataset"?