### PR TITLE
fix: pip installation failing on new python version

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -935,9 +935,9 @@ jobs:
           ./script/make_utils/check_installation_with_all_python.sh --version ${{ matrix.python_version }} --sync_env
 
       # Check installation with pip
-      - name: Check installation with pip and python ${{ matrix.python_version }} (weekly, release)
+      - name: Check installation with pip and python ${{ matrix.python_version }} (weekly)
         if: |
-            (fromJSON(env.IS_WEEKLY) || fromJSON(env.IS_RELEASE))
+            (fromJSON(env.IS_WEEKLY))
             && steps.conformance.outcome == 'success'
             && !cancelled()
         run: |


### PR DESCRIPTION
There is a step in the weekly / release CI that performs `pip install concrete-ml` which actually installs the public latest pypi version of CML. When adding a new supported python version, this step fails. In any case I dont' see the point of testing the previous CML public version in this manner. 