### PR TITLE
fix: propagate GLWE config on hybrid MLP unit test

### DIFF
--- a/tests/torch/test_hybrid_converter.py
+++ b/tests/torch/test_hybrid_converter.py
@@ -64,9 +64,13 @@ def run_hybrid_llm_test(
             m.setitem(sys.modules, "transformers", None)
             if has_pbs_reshape:
                 has_pbs = True
-        if not glwe_backend_installed:
-            m.setattr(concrete.ml.quantization.linear_op_glwe_backend, "_HAS_GLWE_BACKEND", False)
-            m.setattr(concrete.ml.torch.hybrid_model, "_HAS_GLWE_BACKEND", False)
+
+        # Propagate glwe_backend_installed state being tested to constants of affected modules
+        for affected_module in (
+            concrete.ml.quantization.linear_op_glwe_backend,
+            concrete.ml.torch.hybrid_model,
+        ):
+            m.setattr(affected_module, "_HAS_GLWE_BACKEND", glwe_backend_installed)
 
         # Create a hybrid model
         hybrid_model = HybridFHEModel(model, module_names)


### PR DESCRIPTION
### Notes

Fix #927 - Address `test_hybrid_converter.py` failure on MacOS

This fix propagates the GLWE configuration in the hybrid MLP unit test. 
Review needed to confirm if this aligns with the test's original intended behavior.


### Testing
Executed the `make` tasks as outlined in [contributing.md](https://github.com/zama-ai/concrete-ml/blob/main/docs/developer/contributing.md). For pytest, used pytest_no_flaky due to a local unrelated `test_brevitas_qat.py` test failure, which is known to be flaky.
