### PR TITLE
fix: only check signature on PRs

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Check commit signatures
         id: check-commit-signatures
-        if: ${{ !fromJSON(env.IS_WEEKLY) && !fromJSON(env.IS_RELEASE) }}
+        if: ${{ fromJSON(env.IS_PR) }}
         uses: 1Password/check-signed-commits-action@ed2885f3ed2577a4f5d3c3fe895432a557d23d52
 
       - name: Check commits first line format


### PR DESCRIPTION
We require PRs to push to main. The signature checker only works on PRs -> it should run only on PRs.