### PR TITLE
chore: update weekly and release machines

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -200,9 +200,9 @@ jobs:
           # Manage instance type
           INSTANCE_TYPE="c5.4xlarge"
           if [[ "${BUILD_TYPE}" == "weekly" ]]; then
-            INSTANCE_TYPE="m6i.16xlarge"
+            INSTANCE_TYPE="c6i.16xlarge"
           elif [[ "${BUILD_TYPE}" == "release" ]]; then
-            INSTANCE_TYPE="m6i.16xlarge"
+            INSTANCE_TYPE="c6i.16xlarge"
           fi
 
           # Manage python versions


### PR DESCRIPTION
closes https://github.com/zama-ai/concrete-ml-internal/issues/4669
same vcpu machine but more available. ~Also use hpc7a for release~ Actually we need to switch region to get the hpc7a

