### PR TITLE
chore: remove usefless steps in `refresh-one-notebook.yaml` workflow.

### DIFF
--- a/.github/workflows/refresh-one-notebook.yaml
+++ b/.github/workflows/refresh-one-notebook.yaml
@@ -170,18 +170,6 @@ jobs:
         run: |
           ./script/make_utils/setup_os_deps.sh
           make setup_env
-
-      - name: Download Sentiment classification data-sets
-        if: ${{ env.NOTEBOOK_NAME == 'SentimentClassification' }}
-        run: |
-          source .venv/bin/activate
-          cd ./use_case_examples/encrypted_sentiment_analysis && ./download_data.sh
-
-      - name: Download Titanic data-sets
-        if: ${{ env.NOTEBOOK_NAME == 'KaggleTitanic' }}
-        run: |
-          source .venv/bin/activate
-          cd ./use_case_examples/titanic && ./download_data.sh
           
       - name: Refresh ${{ github.event.inputs.notebook }}
         run: |


### PR DESCRIPTION
- `use_case_examples/titanic/download_data.sh` no longer exists.
- `SentimentClassification.ipynb` notebook is in `sentiment_analysis_with_transformer` folder and there is no download_data.sh file.

closes:
- https://github.com/zama-ai/concrete-ml-internal/issues/4692
- https://github.com/zama-ai/concrete-ml-internal/issues/4691