### PR TITLE
fix: restore AdaptiveAvgPool2d in ResNet model

### DIFF
--- a/use_case_examples/resnet/resnet.py
+++ b/use_case_examples/resnet/resnet.py
@@ -213,8 +213,7 @@ class ResNet(nn.Module):
         self.layer4 = self._make_layer(
             block, 512, layers[3], stride=2, dilate=replace_stride_with_dilation[2]
         )
-        # self.avgpool = nn.AdaptiveAvgPool2d((1, 1))  # FIXME
-        self.avgpool = nn.AvgPool2d(kernel_size=7, stride=1, padding=0)
+        self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
         self.fc = nn.Linear(512 * block.expansion, num_classes)
 
         for m in self.modules():


### PR DESCRIPTION
Replace fixed AvgPool2d with AdaptiveAvgPool2d in ResNet implementation.
This change allows the model to handle input images of varying sizes
by automatically adapting the pooling parameters to produce 1x1 output.
The adaptive pooling is more flexible and matches the original ResNet
architecture design.