### PR TITLE
fix: set executor during compile

### DIFF
--- a/src/concrete/ml/torch/hybrid_model.py
+++ b/src/concrete/ml/torch/hybrid_model.py
@@ -655,6 +655,10 @@ class HybridFHEModel:
                         keep_onnx=False,
                     )
 
+                    # Update executor for all remote modules
+                    for module in self.remote_modules.values():
+                        module.executor = self.executor
+
                     vals = self.private_q_modules[name].quant_layers_dict.values()
                     _, q_op = next(iter(vals))
                     const_inp = q_op.constant_inputs[1]  # Get the weights, the bias is in [2]


### PR DESCRIPTION
In this way we can use the GLWE backend in `generate` right after compilation