### PR TITLE
GPU tests in CI

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -451,6 +451,136 @@ jobs:
             echo "No flaky tests were reported!"
           fi
 
+  # ----------------
+  start-runner-gpu-linux:
+      needs: [matrix-preparation]
+      permissions: {}
+      name: Start GPU SLAB runner
+      # This label is irrelevant once the SLAB runner starts.
+      runs-on: ubuntu-24.04
+      
+      timeout-minutes: 15
+      outputs:
+        label: ${{ steps.start-slab-runner.outputs.label }}
+      steps:
+        - name: Configure AWS credentials
+          uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722
+          with:
+            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            aws-region: ${{ secrets.AWS_REGION }}
+              
+        - name: Start SLAB GPU runner
+          id: start-slab-runner
+          if: ${{ !cancelled() }}
+          uses: zama-ai/slab-github-runner@79939325c3c429837c10d6041e4fd8589d328bac
+          with:
+              mode: start
+              github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
+              slab-url: ${{ secrets.SLAB_BASE_URL }}
+              job-secret: ${{ secrets.JOB_SECRET }}
+              backend: aws
+              profile: gpu_ciprofile 
+
+  # GPU-availability:
+  #   name: GPU Availability
+  #   runs-on: ${{ needs.start-runner-gpu-linux.outputs.label }}
+  #   needs: start-runner-gpu-linux
+    
+  #   steps:
+  #     - name: Check GPU availability
+  #       run: |
+  #         echo "Checking for GPU..."
+  #         nvidia-smi || echo "nvidia-smi failed"
+
+  GPU-tests:
+    name: Run GPU tests (Python ${{ matrix.python_version }})
+    runs-on: ${{ needs.start-runner-gpu-linux.outputs.label }}
+    needs: [start-runner-gpu-linux]
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        python_version: [3.8]
+
+    steps:
+      - name: Set Home
+        run: |
+          echo "Set HOME=$(pwd)"
+          echo "HOME=$(pwd)" >> $GITHUB_ENV
+
+      - name: Disable LFS download by default
+        run: |
+
+          apt-get update
+          apt-get install git-lfs
+
+          git lfs install --skip-smudge
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Pull LFS files
+        run: |
+          git lfs pull --include "tests/data/**, src/concrete/ml/pandas/_client_server_files/**" --exclude  ""
+
+      - name: Set up Python ${{ matrix.python_version }}
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        id: setup-python
+        with:
+          python-version: ${{ matrix.python_version }}
+
+      - name: Install Deps
+        id: install-deps
+        run: |
+          echo "Using these tools: $(which python3), $(which pip3)"      
+          ./script/make_utils/setup_os_deps.sh
+          make setup_env
+
+      - name: Install GPU concrete-python
+        id: install-gpu-concrete-python
+        run: |
+          # Show CP version
+          poetry run pip show concrete-python || echo "concrete-python not installed"
+          poetry run pip uninstall -y concrete-python
+
+          
+          # poetry run pip install --extra-index-url https://pypi.zama.ai/gpu concrete-python
+          poetry run pip install --extra-index-url https://pypi.zama.ai/gpu concrete-python==2.10.0
+
+          # Show new CP version
+          poetry run pip show concrete-python || echo "concrete-python not installed"
+
+
+      - name: 🚀 Run GPU Tests
+        run: |
+          make pytest_gpu
+
+  stop-runner-gpu-linux:
+    name: Stop SLAB runner (GPU)
+    needs: [start-runner-gpu-linux, GPU-tests]
+    permissions: {}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    if: ${{ always() && (needs.start-runner-gpu-linux.result != 'skipped') }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Stop SLAB runner
+        uses: zama-ai/slab-github-runner@79939325c3c429837c10d6041e4fd8589d328bac
+        with:
+          mode: stop
+          github-token: ${{ secrets.SLAB_ACTION_TOKEN }}
+          slab-url: ${{ secrets.SLAB_BASE_URL }}
+          job-secret: ${{ secrets.JOB_SECRET }}
+          label: ${{ needs.start-runner-gpu-linux.outputs.label }}
+
+# -------------
   decide-slack-report:
     name: Decide Slack report
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -844,3 +844,18 @@ check_symlinks:
 		echo "Bad symlinks found: " && echo $$(find . -xtype l) && \
 		exit 1; \
 	fi
+
+.PHONY: pytest_gpu  # Run only tests that require a GPU
+pytest_gpu:
+	@echo "Collecting GPU tests..."
+
+	@TESTS=$$(poetry run pytest -m "use_gpu" --collect-only -q); \
+	if [ -z "$$TESTS" ]; then \
+		echo "No tests marked @pytest.mark.use_gpu found."; \
+		exit 1; \
+	else \
+		echo "Tests found:"; \
+		echo "$$TESTS"; \
+		echo "Running GPU tests only..."; \
+		env POETRY_RUN_GPU_TESTS=1 poetry run pytest -m "use_gpu" -vvs --color=yes --durations=20; \
+	fi

--- a/ci/slab.toml
+++ b/ci/slab.toml
@@ -27,6 +27,11 @@ instance_type = "c5.4xlarge"
 subnet_id = "subnet-a029b7ed"
 security_group= ["sg-0bf1c1d79c97bc88f", ]
 
+[backend.aws.gpu_ciprofile]
+region = "us-east-1"
+image_id = "ami-0c2e815dbef0da3a2"
+instance_type = "g4dn.8xlarge"
+
 [backend.aws.big-cpu]
 region = "eu-west-1"
 image_id = "ami-0898af27b3e2421d8"

--- a/conftest.py
+++ b/conftest.py
@@ -307,9 +307,8 @@ def get_device():
 
 @pytest.fixture()
 def enforce_gpu_determinism():
-    print(f"CUBLAS_WORKSPACE_CONFIG = {os.environ.get('CUBLAS_WORKSPACE_CONFIG')}")
+    """Pytest fixture to enforce deterministic behavior on GPU operations."""
     os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
-    print(f"CUBLAS_WORKSPACE_CONFIG = {os.environ.get('CUBLAS_WORKSPACE_CONFIG')}")
     torch.use_deterministic_algorithms(True, warn_only=True)
 
 

--- a/src/concrete/ml/torch/compile.py
+++ b/src/concrete/ml/torch/compile.py
@@ -347,11 +347,6 @@ def compile_torch_model(
         "using compile_brevitas_qat_model instead.",
     )
 
-    assert_true(
-        (model_device := str(next(torch_model.parameters()).device)).startswith(device),
-        f"❌ Device mismatch: Model is on {model_device}, but 'device' param is {device}",
-    )
-
     return _compile_torch_or_onnx_model(
         torch_model,
         torch_inputset,

--- a/src/concrete/ml/torch/hybrid_model.py
+++ b/src/concrete/ml/torch/hybrid_model.py
@@ -618,7 +618,8 @@ class HybridFHEModel:
         self.set_fhe_mode(HybridFHEMode.CALIBRATE)
 
         # Set correct device
-        x = x.to(device)
+        if isinstance(x, torch.Tensor):
+            x = x.to(device)
         self.model = self.model.to(device)
 
         # Run the model to get the calibration data

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -85,12 +85,12 @@ def test_data_processing_invalid_input(input_type, load_data):
             _ = data_calibration_processing(data=x, targets=y, n_sample=1)
 
 
-def test_cuda_compilation_warnings(get_device_for_compilation):
+def test_cuda_compilation_warnings(get_device):
     """Test that cuda compilation options are correctly handled."""
 
     # If testing on a CUDA enabled machine, there will be no warnings
     # there's nothing to test
-    if get_device_for_compilation("execute") == "cuda":
+    if "cuda" in get_device:
         if not check_gpu_enabled():
             raise AssertionError(
                 "Trying to run CUDA test on a non-CUDA machine. "

--- a/tests/deployment/test_client_server.py
+++ b/tests/deployment/test_client_server.py
@@ -67,6 +67,7 @@ class OnDiskNetwork:
 
 # This is a known flaky test
 # FIXME: https://github.com/zama-ai/concrete-ml-internal/issues/4014
+@pytest.mark.use_gpu
 @pytest.mark.flaky
 @pytest.mark.parametrize("model_class, parameters", MODELS_AND_DATASETS)
 @pytest.mark.parametrize("n_bits", [2])
@@ -79,6 +80,7 @@ def test_client_server_sklearn_inference(
     check_is_good_execution_for_cml_vs_circuit,
     check_array_equal,
     check_float_array_equal,
+    get_device,
 ):
     """Test the client-server interface for built-in models' inference."""
 
@@ -118,6 +120,7 @@ def test_client_server_sklearn_inference(
     compilation_kwargs = {
         "X": x_train,
         "configuration": default_configuration,
+        "device": get_device,
     }
 
     # Compile the model

--- a/tests/sklearn/test_sklearn_models.py
+++ b/tests/sklearn/test_sklearn_models.py
@@ -2421,7 +2421,7 @@ def test_tfhers_inputs_outputs_trees(model_class, parameters, n_bits, load_data,
 @pytest.mark.parametrize(
     "model_class, parameters", get_sklearn_tree_models_and_datasets(True, True)
 )
-def test_tfhers_trees_non_8b_not_working(model_class, parameters, load_data, device):
+def test_tfhers_trees_non_8b_not_working(model_class, parameters, load_data):
     """Check that non-supported configs for tree models for TFHE-rs inputs raise an exception."""
     n_bits = 4
 
@@ -2430,7 +2430,7 @@ def test_tfhers_trees_non_8b_not_working(model_class, parameters, load_data, dev
     model.fit(x, y)
 
     with pytest.raises(AssertionError, match=".*supported for 8-bit tree-based.*"):
-        model.compile(x, ciphertext_format=CiphertextFormat.TFHE_RS, device=device)
+        model.compile(x, ciphertext_format=CiphertextFormat.TFHE_RS)
 
 
 @pytest.mark.parametrize(

--- a/tests/sklearn/test_sklearn_models.py
+++ b/tests/sklearn/test_sklearn_models.py
@@ -33,7 +33,6 @@ import tempfile
 import warnings
 from typing import Any, Dict, List
 
-import concrete.compiler
 import numpy
 import pandas
 import pytest

--- a/tests/sklearn/test_sklearn_models.py
+++ b/tests/sklearn/test_sklearn_models.py
@@ -33,6 +33,7 @@ import tempfile
 import warnings
 from typing import Any, Dict, List
 
+import concrete.compiler
 import numpy
 import pandas
 import pytest
@@ -1732,6 +1733,7 @@ def test_pipeline(
     check_pipeline(model_class, x, y)
 
 
+# @pytest.mark.use_gpu
 @pytest.mark.parametrize("model_class, parameters", MODELS_AND_DATASETS)
 @pytest.mark.parametrize(
     "simulate",
@@ -1764,7 +1766,7 @@ def test_predict_correctness(
     n_bits,
     load_data,
     default_configuration,
-    get_device_for_compilation,
+    get_device,
     check_is_good_execution_for_cml_vs_circuit,
     is_weekly_option,
     verbose=True,
@@ -1789,7 +1791,7 @@ def test_predict_correctness(
     model.compile(
         x,
         default_configuration,
-        device=get_device_for_compilation("simulate" if simulate else "execute"),
+        device=get_device,
     )
 
     if verbose:
@@ -2372,12 +2374,13 @@ def test_xgb_serialization_errors(model_class, param, error_message):
             model.dumps()
 
 
+# @pytest.mark.use_gpu
 @pytest.mark.flaky
 @pytest.mark.parametrize(
     "model_class, parameters", get_sklearn_tree_models_and_datasets(True, True)
 )
 @pytest.mark.parametrize("n_bits", [4, 8, 12])
-def test_tfhers_inputs_outputs_trees(model_class, parameters, n_bits, load_data):
+def test_tfhers_inputs_outputs_trees(model_class, parameters, n_bits, load_data, get_device):
     """Check that 8b tree-based classifiers work with TFHE-rs inputs/outputs."""
 
     x, y = get_dataset(model_class, parameters, n_bits, load_data, True)
@@ -2393,16 +2396,16 @@ def test_tfhers_inputs_outputs_trees(model_class, parameters, n_bits, load_data)
     # an error is raised
     if not n_bits == 8 or is_regressor_or_partial_regressor(model_class):
         with pytest.raises(AssertionError, match=".*supported for 8-bit tree-based.*"):
-            model.compile(x, ciphertext_format=CiphertextFormat.TFHE_RS)
+            model.compile(x, ciphertext_format=CiphertextFormat.TFHE_RS, device=get_device)
         return
 
     # Check that we can first compile to Concrete, then to
     # TFHE-rs input/outputs then to concrete again
-    model.compile(x)
+    model.compile(x, device=get_device)
 
     y_pred_concrete = model.predict(fhe_test_data, fhe="execute")
 
-    model.compile(x, ciphertext_format=CiphertextFormat.TFHE_RS)
+    model.compile(x, ciphertext_format=CiphertextFormat.TFHE_RS, device=get_device)
 
     with pytest.raises(ValueError, match="Simulation with TFHE-rs ciphertext.*"):
         model.predict(fhe_test_data, fhe="simulate")
@@ -2410,7 +2413,7 @@ def test_tfhers_inputs_outputs_trees(model_class, parameters, n_bits, load_data)
     # Run the model in FHE for TFHE-rs inputs/outputs
     y_pred_tfhers = model.predict(fhe_test_data, fhe="execute")
 
-    model.compile(x)
+    model.compile(x, device=get_device)
 
     # Check correctness with TFHE-rs inputs/outputs
     assert numpy.all(y_pred_tfhers == y_pred_concrete)
@@ -2419,7 +2422,7 @@ def test_tfhers_inputs_outputs_trees(model_class, parameters, n_bits, load_data)
 @pytest.mark.parametrize(
     "model_class, parameters", get_sklearn_tree_models_and_datasets(True, True)
 )
-def test_tfhers_trees_non_8b_not_working(model_class, parameters, load_data):
+def test_tfhers_trees_non_8b_not_working(model_class, parameters, load_data, device):
     """Check that non-supported configs for tree models for TFHE-rs inputs raise an exception."""
     n_bits = 4
 
@@ -2428,7 +2431,7 @@ def test_tfhers_trees_non_8b_not_working(model_class, parameters, load_data):
     model.fit(x, y)
 
     with pytest.raises(AssertionError, match=".*supported for 8-bit tree-based.*"):
-        model.compile(x, ciphertext_format=CiphertextFormat.TFHE_RS)
+        model.compile(x, ciphertext_format=CiphertextFormat.TFHE_RS, device=device)
 
 
 @pytest.mark.parametrize(

--- a/tests/sklearn/test_sklearn_models.py
+++ b/tests/sklearn/test_sklearn_models.py
@@ -1733,7 +1733,7 @@ def test_pipeline(
     check_pipeline(model_class, x, y)
 
 
-# @pytest.mark.use_gpu
+@pytest.mark.use_gpu
 @pytest.mark.parametrize("model_class, parameters", MODELS_AND_DATASETS)
 @pytest.mark.parametrize(
     "simulate",
@@ -2374,7 +2374,7 @@ def test_xgb_serialization_errors(model_class, param, error_message):
             model.dumps()
 
 
-# @pytest.mark.use_gpu
+@pytest.mark.use_gpu
 @pytest.mark.flaky
 @pytest.mark.parametrize(
     "model_class, parameters", get_sklearn_tree_models_and_datasets(True, True)

--- a/tests/torch/test_compile_torch.py
+++ b/tests/torch/test_compile_torch.py
@@ -453,7 +453,7 @@ def test_compile_torch_or_onnx_networks(
     get_and_compile,
     check_is_good_execution_for_cml_vs_circuit,
     is_weekly_option,
-    get_device_for_compilation,
+    get_device,
 ):
     """Test the different model architecture from torch numpy."""
 
@@ -476,7 +476,7 @@ def test_compile_torch_or_onnx_networks(
         check_is_good_execution_for_cml_vs_circuit=check_is_good_execution_for_cml_vs_circuit,
         verbose=False,
         get_and_compile=get_and_compile,
-        device=get_device_for_compilation("simulate" if simulate else "execute"),
+        device=get_device,
     )
 
 

--- a/tests/torch/test_hybrid_converter.py
+++ b/tests/torch/test_hybrid_converter.py
@@ -45,6 +45,7 @@ def run_hybrid_llm_test(
     transformers_installed: bool,
     glwe_backend_installed: bool,
     monkeypatch: pytest.MonkeyPatch,
+    get_device: str,
 ):
     """Run the test for any model with its private module names."""
 
@@ -70,6 +71,7 @@ def run_hybrid_llm_test(
             n_bits=9,
             rounding_threshold_bits=8,
             configuration=configuration,
+            device=get_device,
         )
     except RuntimeError as error:
         # Skip test if NoParametersFound error occurs
@@ -138,6 +140,7 @@ def run_hybrid_llm_test(
                 assert "client.zip" in files and "server.zip" in files
 
 
+# # @pytest.mark.use_gpu
 # Dependency 'huggingface-hub' raises a 'FutureWarning' from version 0.23.0 when calling the
 # 'from_pretrained' method
 @pytest.mark.filterwarnings("ignore::FutureWarning")
@@ -158,15 +161,17 @@ def test_gpt2_hybrid_mlp(
     transformers_installed,
     glwe_backend_installed,
     monkeypatch,
+    get_device,
+    enforce_gpu_determinism,
 ):
     """Test GPT2 hybrid."""
 
     # Get GPT2 from Hugging Face
     model_name = "gpt2"
-    model = GPT2LMHeadModel.from_pretrained(model_name)
+    model = GPT2LMHeadModel.from_pretrained(model_name).to(get_device)
     tokenizer = GPT2Tokenizer.from_pretrained(model_name)
     prompt = "A long time ago,"
-    input_ids = tokenizer.encode(prompt, return_tensors="pt")
+    input_ids = tokenizer.encode(prompt, return_tensors="pt").to(get_device)
 
     # Run the test with using a single module in FHE
     assert isinstance(model, torch.nn.Module)
@@ -179,10 +184,13 @@ def test_gpt2_hybrid_mlp(
         transformers_installed,
         glwe_backend_installed,
         monkeypatch,
+        get_device,
     )
 
 
-def test_hybrid_brevitas_qat_model():
+# # # @pytest.mark.use_gpu
+@pytest.mark.filterwarnings("ignore:.*kthvalue CUDA does not have a deterministic implementation.*")
+def test_hybrid_brevitas_qat_model(get_device, enforce_gpu_determinism):
     """Test GPT2 hybrid."""
     n_bits = 3
     input_shape = 32
@@ -200,7 +208,7 @@ def test_hybrid_brevitas_qat_model():
     model(inputs)
     assert isinstance(model, torch.nn.Module)
     hybrid_model = HybridFHEModel(model, module_names="sub_module")
-    hybrid_model.compile_model(x=inputs)
+    hybrid_model.compile_model(x=inputs, device=get_device)
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_dir_path = Path(temp_dir)
@@ -239,21 +247,24 @@ def test_invalid_model():
         HybridFHEModel(invalid_model, module_names="sub_module")
 
 
+# # @pytest.mark.use_gpu
 @pytest.mark.parametrize("use_dynamic_quantization, n_bits", [(True, 8), (False, 10)])
 @pytest.mark.parametrize("n_hidden", [256, 512, 2048])
-def test_hybrid_glwe_correctness(n_hidden, use_dynamic_quantization, n_bits):
+def test_hybrid_glwe_correctness(
+    n_hidden, use_dynamic_quantization, n_bits, get_device, enforce_gpu_determinism
+):
     """Tests that the GLWE backend produces correct results for the hybrid model."""
 
     num_samples = 200
 
-    def prepare_data(x, y, test_size=0.1, random_state=42):
+    def prepare_data(x, y, test_size=0.1, random_state=42, device="cpu"):
         x_train, x_test, y_train, y_test = train_test_split(
             x, y, test_size=test_size, random_state=random_state
         )
-        x_train = torch.tensor(x_train, dtype=torch.float32)
-        x_test = torch.tensor(x_test, dtype=torch.float32)
-        y_train = torch.tensor(y_train, dtype=torch.long)
-        y_test = torch.tensor(y_test, dtype=torch.long)
+        x_train = torch.tensor(x_train, dtype=torch.float32).to(device)
+        x_test = torch.tensor(x_test, dtype=torch.float32).to(device)
+        y_train = torch.tensor(y_train, dtype=torch.long).to(device)
+        y_test = torch.tensor(y_test, dtype=torch.long).to(device)
         return x_train, x_test, y_train, y_test
 
     # Generate random data with n_hidden features and n_hidden classes
@@ -262,9 +273,9 @@ def test_hybrid_glwe_correctness(n_hidden, use_dynamic_quantization, n_bits):
     y1_data = numpy.random.randint(0, n_hidden, size=num_samples)  # n_hidden classes
 
     # Prepare data
-    x1_train, x1_test, y1_train, y1_test = prepare_data(x1_data, y1_data)
+    x1_train, x1_test, y1_train, y1_test = prepare_data(x1_data, y1_data, device=get_device)
 
-    model = FCSmall(n_hidden, torch.nn.ReLU, hidden=n_hidden)
+    model = FCSmall(n_hidden, torch.nn.ReLU, hidden=n_hidden).to(get_device)
     optimizer = torch.optim.Adam(model.parameters())
 
     num_epochs = 100
@@ -283,7 +294,7 @@ def test_hybrid_glwe_correctness(n_hidden, use_dynamic_quantization, n_bits):
         if isinstance(p, torch.nn.Linear):
             param_names.append(k)
 
-    y_torch = model(x1_test).detach().numpy()
+    y_torch = model(x1_test).detach().cpu().numpy()
     hybrid_local = HybridFHEModel(model, param_names)
 
     # This internal flag tells us whether all the layers
@@ -294,17 +305,20 @@ def test_hybrid_glwe_correctness(n_hidden, use_dynamic_quantization, n_bits):
     assert is_pure_linear == should_use_glwe
 
     hybrid_local.compile_model(
-        x1_train, n_bits=n_bits, use_dynamic_quantization=use_dynamic_quantization
+        x1_train,
+        n_bits=n_bits,
+        use_dynamic_quantization=use_dynamic_quantization,
+        device=get_device,
     )
 
-    y_qm = hybrid_local(x1_test, fhe="disable").numpy()
-    y_hybrid_torch = hybrid_local(x1_test, fhe="torch").detach().numpy()
+    y_qm = hybrid_local(x1_test, fhe="disable").cpu().numpy()
+    y_hybrid_torch = hybrid_local(x1_test, fhe="torch").detach().cpu().numpy()
 
     # Only test GLWE execution if input dimension is >= 512
     if should_use_glwe:
-        y_glwe = hybrid_local(x1_test, fhe="execute").numpy()
+        y_glwe = hybrid_local(x1_test, fhe="execute").cpu().numpy()
 
-        y1_test = y1_test.numpy()
+        y1_test = y1_test.cpu().numpy()
         n_correct_fp32 = numpy.sum(numpy.argmax(y_torch, axis=1) == y1_test)
         n_correct_qm = numpy.sum(numpy.argmax(y_qm, axis=1) == y1_test)
         n_correct_glwe = numpy.sum(numpy.argmax(y_glwe, axis=1) == y1_test)

--- a/tests/torch/test_hybrid_converter.py
+++ b/tests/torch/test_hybrid_converter.py
@@ -162,7 +162,7 @@ def test_gpt2_hybrid_mlp(
     glwe_backend_installed,
     monkeypatch,
     get_device,
-    enforce_gpu_determinism,
+    enforce_gpu_determinism,  # pylint: disable=unused-argument
 ):
     """Test GPT2 hybrid."""
 
@@ -190,7 +190,9 @@ def test_gpt2_hybrid_mlp(
 
 # # # @pytest.mark.use_gpu
 @pytest.mark.filterwarnings("ignore:.*kthvalue CUDA does not have a deterministic implementation.*")
-def test_hybrid_brevitas_qat_model(get_device, enforce_gpu_determinism):
+def test_hybrid_brevitas_qat_model(
+    get_device, enforce_gpu_determinism
+):  # pylint: disable=unused-argument
     """Test GPT2 hybrid."""
     n_bits = 3
     input_shape = 32
@@ -252,7 +254,7 @@ def test_invalid_model():
 @pytest.mark.parametrize("n_hidden", [256, 512, 2048])
 def test_hybrid_glwe_correctness(
     n_hidden, use_dynamic_quantization, n_bits, get_device, enforce_gpu_determinism
-):
+):  # pylint: disable=unused-argument
     """Tests that the GLWE backend produces correct results for the hybrid model."""
 
     num_samples = 200

--- a/tests/torch/test_hybrid_converter.py
+++ b/tests/torch/test_hybrid_converter.py
@@ -140,7 +140,7 @@ def run_hybrid_llm_test(
                 assert "client.zip" in files and "server.zip" in files
 
 
-# # @pytest.mark.use_gpu
+@pytest.mark.use_gpu
 # Dependency 'huggingface-hub' raises a 'FutureWarning' from version 0.23.0 when calling the
 # 'from_pretrained' method
 @pytest.mark.filterwarnings("ignore::FutureWarning")
@@ -188,7 +188,7 @@ def test_gpt2_hybrid_mlp(
     )
 
 
-# # # @pytest.mark.use_gpu
+@pytest.mark.use_gpu
 @pytest.mark.filterwarnings("ignore:.*kthvalue CUDA does not have a deterministic implementation.*")
 def test_hybrid_brevitas_qat_model(
     get_device, enforce_gpu_determinism
@@ -249,7 +249,7 @@ def test_invalid_model():
         HybridFHEModel(invalid_model, module_names="sub_module")
 
 
-# # @pytest.mark.use_gpu
+@pytest.mark.use_gpu
 @pytest.mark.parametrize("use_dynamic_quantization, n_bits", [(True, 8), (False, 10)])
 @pytest.mark.parametrize("n_hidden", [256, 512, 2048])
 def test_hybrid_glwe_correctness(

--- a/tests/torch/test_training.py
+++ b/tests/torch/test_training.py
@@ -105,7 +105,9 @@ def train_and_evaluate_model(
 
 
 @pytest.mark.use_gpu
-def test_sgd_training_manual(get_device, enforce_gpu_determinism):
+def test_sgd_training_manual(
+    get_device, enforce_gpu_determinism
+):  # pylint: disable=unused-argument
     """Trains a logistic regression with SGD in torch and quantized."""
     # Train on the bias when multi output is available in concrete
     # FIXME: https://github.com/zama-ai/concrete-ml-internal/issues/4131

--- a/tests/torch/test_training.py
+++ b/tests/torch/test_training.py
@@ -1,6 +1,7 @@
 """Tests for FHE training."""
 
 import numpy
+import pytest
 import torch
 from sklearn import datasets
 from sklearn.linear_model import LogisticRegression
@@ -36,7 +37,15 @@ def initialize_parameters(n_batch, n_features, n_targets, min_val=-3.0, max_val=
 
 
 def train_and_evaluate_model(
-    x_train, y_train, x_test, y_test, batch_size, iteration, model, model_type="torch"
+    x_train,
+    y_train,
+    x_test,
+    y_test,
+    batch_size,
+    iteration,
+    model,
+    model_type="torch",
+    device="cpu",
 ):
     """
     Train and evaluate the given model, supporting both torch and quantized models.
@@ -85,7 +94,8 @@ def train_and_evaluate_model(
     return accuracy_score(y_test[:min_length], predictions[:min_length])
 
 
-def test_sgd_training_manual():
+@pytest.mark.use_gpu
+def test_sgd_training_manual(get_device):
     """Trains a logistic regression with SGD in torch and quantized."""
     # Train on the bias when multi output is available in concrete
     # FIXME: https://github.com/zama-ai/concrete-ml-internal/issues/4131
@@ -107,7 +117,15 @@ def test_sgd_training_manual():
 
     # Train and evaluate custom logistic regression model
     accuracy_torch = train_and_evaluate_model(
-        x_train, y_train, x_test, y_test, batch_size, iteration, model, model_type="torch"
+        x_train,
+        y_train,
+        x_test,
+        y_test,
+        batch_size,
+        iteration,
+        model,
+        model_type="torch",
+        device=get_device,
     )
 
     # Train and evaluate sklearn logistic regression model
@@ -119,7 +137,15 @@ def test_sgd_training_manual():
     ), "Torch accuracy should be within 1% of sklearn's."
 
     accuracy_q_module = train_and_evaluate_model(
-        x_train, y_train, x_test, y_test, batch_size, iteration, model, model_type="quantized"
+        x_train,
+        y_train,
+        x_test,
+        y_test,
+        batch_size,
+        iteration,
+        model,
+        model_type="quantized",
+        device=get_device,
     )
 
     # Quantized accuracy should match torch

--- a/tests/torch/test_training.py
+++ b/tests/torch/test_training.py
@@ -81,7 +81,7 @@ def train_and_evaluate_model(
             n_bits=n_bits,
             device=device,
         )
-        trained_weights = weights.detach().numpy()
+        trained_weights = weights.detach().cpu().numpy()
         for i in range(iteration):
             trained_weights = q_module.forward(
                 x_train_batches.detach().cpu().numpy()[[i]],


### PR DESCRIPTION
Steps:
- Add new machine [g4dn.2xlarge](https://aws.amazon.com/ec2/instance-types/g4/) to `ci/slab.toml` under `[backend.aws.gpu_ciprofile]` tag, to pick up the SHA see: https://github.com/zama-ai/slab-github-runner
- Add the gpu marker, in conftest.py
- Target the tests to run with gpu
- Add gpu setup in .github/workflows/continuous-integration.yaml


Current issues: 
- [x] (solved) GPU not recognized in the slab runner
  The `start-runner-gpu-linux`  step runs on `ubuntu-24.04` and starts the GPU instance, `invidia-smi` won't work inside it.
- [x] No space left in the device
  The AMI size is defined at build time (see: `/dev/root` using `df -h`). Increasing the instance type won't affect disk space — we must expand the AMI storage and create a new snapshot:

      Reminder:
      A snapshot is an incremental backup of an EBS volume (the "hard drive" of an EC2 instance), capturing its exact state at a given moment.

      Steps:
      Launch an EC2 instanc:  Manually increase EBS storage via Configure Storage > Launch instance > Actions > Image & Templates > Create Image.

      <!> Don't forget to terminate the EC2 instance used for resizing and snapshot the ami image.
- [x] (solved) Error with concrete-python 2.24.0
    `pip install --extra-index-url https://pypi.zama.ai/gpu concrete-python` downloads `concrete-python 2.24.0` but CML is based on `concrete-python 2.10.0`. We encounter a breaking change -> `TypeError: fork() got an unexpected keyword argument 'optim_lsbs_with_lut'`

- [x] (solved) Reproducibility error with GPU
     ```FAILED tests/torch/test_hybrid_converter.py::test_hybrid_glwe_correctness[2048-False-10] - RuntimeError: Deterministic behavior was enabled with either `torch.use_deterministic_algorithms(True)` or `at::Context::setDeterministicAlgorithms(true)`, but this operation is not deterministic because it uses CuBLAS and you have CUDA >= 10.2. To enable deterministic behavior in this case, you must set an environment variable before running your PyTorch application: CUBLAS_WORKSPACE_CONFIG=:4096:8 or CUBLAS_WORKSPACE_CONFIG=:16:8. For more information, go to https://docs.nvidia.com/cuda/cublas/index.html#results-reproducibility```
  I added a fixture `enforce_gpu_determinism` 


All tests take less than 20 minutes.  

closes  [4723](https://github.com/zama-ai/concrete-ml-internal/issues/4723)
ref [previous work](https://github.com/zama-ai/concrete-ml/compare/main...feat/add_gpu_tests)