### PR TITLE
docs: remove broken Zama developer survey links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,8 +62,4 @@ Collaborate with us to advance the FHE spaces and drive innovation together.
 
 ______________________________________________________________________
 
-{% hint style="success" %}
-**Zama 5-Question Developer Survey**
 
-We want to hear from you! Take 1 minute to share your thoughts and helping us enhance our documentation and libraries. **👉** [**Click here**](https://www.zama.ai/developer-survey) to participate.
-{% endhint %}

--- a/docs/built-in-models/linear.md
+++ b/docs/built-in-models/linear.md
@@ -128,8 +128,4 @@ y_pred_fhe = cml_model.predict(X_test, fhe="execute")
 
 ```
 
-{% hint style="success" %}
-**Zama 5-Question Developer Survey**
 
-We want to hear from you! Take 1 minute to share your thoughts and help us enhance our documentation and libraries. **👉** [**Click here**](https://www.zama.ai/developer-survey) to participate.
-{% endhint %}

--- a/docs/deep-learning/torch_support.md
+++ b/docs/deep-learning/torch_support.md
@@ -252,8 +252,4 @@ Concrete ML also supports some of their QAT equivalents from Brevitas.
 The equivalent versions from `torch.functional` are also supported.
 {% endhint %}
 
-{% hint style="success" %}
-**Zama 5-Question Developer Survey**
 
-We want to hear from you! Take 1 minute to share your thoughts and helping us enhance our documentation and libraries. **👉** [**Click here**](https://www.zama.ai/developer-survey) to participate.
-{% endhint %}

--- a/docs/getting-started/pip_installing.md
+++ b/docs/getting-started/pip_installing.md
@@ -79,8 +79,4 @@ Alternatively, you can launch a shell in Docker, with or without volumes:
 docker run --rm -it zamafhe/concrete-ml /bin/bash
 ```
 
-{% hint style="success" %}
-**Zama 5-Question Developer Survey**
 
-We want to hear from you! Take 1 minute to share your thoughts and helping us enhance our documentation and libraries. **👉** [**Click here**](https://www.zama.ai/developer-survey) to participate.
-{% endhint %}

--- a/docs/tutorials/showcase.md
+++ b/docs/tutorials/showcase.md
@@ -46,8 +46,4 @@
 - [Train a linear classifier on encrypted data using Concrete ML and Fully Homomorphic Encryption (FHE)](https://www.zama.ai/post/video-tutorial-train-a-linear-classifier-on-encrypted-data-using-concrete-ml-and-fully-homomorphic-encryption-fhe) - February 2024
 - [How to convert a scikit-learn model into its homomorphic equivalent](https://www.zama.ai/post/how-to-convert-a-scikit-learn-model-into-its-homomorphic-equivalent) - June 2023
 
-{% hint style="success" %}
-**Zama 5-Question Developer Survey**
 
-We want to hear from you! Take 1 minute to share your thoughts and helping us enhance our documentation and libraries. **👉** [**Click here**](https://www.zama.ai/developer-survey) to participate.
-{% endhint %}


### PR DESCRIPTION
- Remove broken survey links from 5 documentation files
- Links to https://www.zama.ai/developer-survey return 404
- Affected files:
  - docs/README.md
  - docs/built-in-models/linear.md
  - docs/deep-learning/torch_support.md
  - docs/getting-started/pip_installing.md
  - docs/tutorials/showcase.md

Fixes broken links that were causing user confusion.