### PR TITLE
chore: disable monthly benchmark and weekly timing schedules

### DIFF
--- a/.github/workflows/ci_timing.yaml
+++ b/.github/workflows/ci_timing.yaml
@@ -4,11 +4,11 @@ name: CML build time
 on:
   workflow_dispatch:
 
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    # At 22:00 on Sunday
-    # Timezone is UTC, so Paris time is +2 during the summer and +1 during winter
-    - cron: '0 22 * * 0'
+  # schedule:
+  #   # * is a special character in YAML so you have to quote this string
+  #   # At 22:00 on Sunday
+  #   # Timezone is UTC, so Paris time is +2 during the summer and +1 during winter
+  #   - cron: '0 22 * * 0'
 
 permissions:
   contents: read

--- a/.github/workflows/cifar_benchmark.yaml
+++ b/.github/workflows/cifar_benchmark.yaml
@@ -1,7 +1,7 @@
 name: CIFAR-10 benchmark CML
 on:
-  schedule:
-    - cron: '0 0 1 * *'
+  # schedule:
+  #   - cron: '0 0 1 * *'
   workflow_dispatch:
     inputs:
       git-ref:

--- a/.github/workflows/llama_finetuning_benchmark.yaml
+++ b/.github/workflows/llama_finetuning_benchmark.yaml
@@ -1,7 +1,7 @@
 name: LLama Fine-tuning Benchmark CML
 on:
-  schedule:
-    - cron: '0 0 1 * *'
+  # schedule:
+  #   - cron: '0 0 1 * *'
   workflow_dispatch:
     inputs:
       git-ref:

--- a/.github/workflows/resnet_hybrid_model.yaml
+++ b/.github/workflows/resnet_hybrid_model.yaml
@@ -1,7 +1,7 @@
 name: ResNet Hybrid FHE Benchmark CML
 on:
-  schedule:
-    - cron: '0 0 1 * *'
+  # schedule:
+  #   - cron: '0 0 1 * *'
   workflow_dispatch:
     inputs:
       git-ref:


### PR DESCRIPTION
## Why

These four scheduled workflows have produced **nothing but failures since June**, and three of them provision real EC2/GPU capacity to do it.

Job-level breakdown of a single monthly cycle (1st of each month):

| Workflow | What it provisions | Outcome |
|---|---|---|
| LLama Fine-tuning | EC2 `gpu_ciprofile` (183s setup) + `big-cpu` (83s) | both jobs fail (326s, 456s) |
| CIFAR-10 | EC2 CPU (115s) + **Hyperstack GPU** (593s setup) | both jobs fail (382s, 433s) |
| ResNet Hybrid | EC2 (85s setup) | fails (336s) |
| CML build time | GitHub-hosted (free) | 9/9 failures, Slack noise only |

So every month we boot ~3 EC2 boxes and 2 GPU instances, hold them 7-17 minutes, and get failures. GitHub's billing API reports `0 billable minutes` for all of it because the spend lands on the AWS/Hyperstack bill, not GitHub's — which is why this went unnoticed.

Run history on this repo since 2026-06-04 confirms there is no other activity to speak of: 6 failing benchmark runs, 9 failing build-time runs, 6 free CodeQL scans, and a single push-triggered CI run.

## What changed

Commented out the `schedule:` trigger in:

- `cifar_benchmark.yaml`
- `llama_finetuning_benchmark.yaml`
- `resnet_hybrid_model.yaml`
- `ci_timing.yaml`

`workflow_dispatch` is untouched in all four, so they can still be run on demand from the Actions tab.

## Deliberately NOT changed

`continuous-integration.yaml` (PR/push/release), `release.yaml`, `publish_aws_ami.yaml`, `check_github_actions.yaml` and `sync_on_push.yaml` keep their automatic triggers. They are either free (GitHub-hosted on a public repo) or fire only on deliberate human action such as publishing a release, so they are not passive spend.

CodeQL default setup also still runs weekly. It is free on a public repo and is configured in repo settings rather than a workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)